### PR TITLE
存在しない環境変数が与えられた場合の処理を追加

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -75,10 +75,10 @@ char	*expand_environment_variable(char *data, size_t replace_start, t_env_var *v
 	char	*env_value;
 
 	env_value = search_env_vars(data, replace_start + 1, vars);
-	if (!env_value)
-		return (data);
-	data = str_insert(data, replace_start, env_value, ft_strlen(env_value));
-	return (data);
+	if (env_value)
+		return (str_insert(data, replace_start, env_value, ft_strlen(env_value)));
+	else
+		return (str_insert(data, replace_start, "", 0));
 }
 
 char	*expand_wildcard(char *data, size_t pre_len, t_env_var *vars)

--- a/expander/expander_env.c
+++ b/expander/expander_env.c
@@ -19,7 +19,6 @@ char	*search_env_vars(char *data, size_t var_start, t_env_var *vars)
 		vars = vars->next;
 	if (vars)
 		return (vars->value);
-		// todo: 環境変数が見つからなかった場合の処理
 	else
 		return (NULL);
 }


### PR DESCRIPTION
- Update: return empty string when non-existent environment variable is entered

## Purpose
存在しない環境変数が与えられた時、`$HOGE`なら空文字列を返すべきだが、そのまま`$HOGE`と返してしまっていたので、修正。

以下のように、途中まで普通の文字列でも環境変数のみ空文字列になるので安心！

```bash
input:echo $HOGE
{Index: 0, Level: 0, Literal:'echo'}
{Index: 1, Level: 1, Literal:''}

input:echo hello$HOGE
{Index: 0, Level: 0, Literal:'echo'}
{Index: 1, Level: 1, Literal:'hello'}
```

## Effect
後のexpansionで悪さしそうな要素がまた消えました笑

## Test
```bash
$ pwd
/expnader/test
$ make
```

## Memo