### PR TITLE
簡単なwordsplittingを実装

### DIFF
--- a/expander/expander.h
+++ b/expander/expander.h
@@ -50,6 +50,8 @@ char		*sort_strings(char *src);
 bool		is_quoted(const char *str);
 size_t		unquoted_strlen(const char *str);
 
+// expander_splitting.c
+char	**word_split(char const *s, const char *set);
 
 #endif
 

--- a/expander/expander_splitting.c
+++ b/expander/expander_splitting.c
@@ -1,0 +1,107 @@
+#include "expander.h"
+
+static bool	match_check(char c, char const *set)
+{
+	size_t	j;
+
+	j = 0;
+	while (set[j])
+	{
+		if (set[j] == c)
+			return (true);
+		j++;
+	}
+	return (false);
+}
+
+static char	**row_malloc_split(char const *str, const char *set, size_t *row)
+{
+	size_t	len;
+	size_t	i;
+	char	**split;
+
+	i = 0;
+	len = 0;
+	while (str[i])
+	{
+		if (!match_check(str[i], set))
+		{
+			while (!match_check(str[i], set) && str[i])
+				i++;
+			len++;
+		}
+		if (!str[i])
+			break ;
+		i++;
+	}
+	split = (char **)malloc(sizeof(char *) * (len + 1));
+	if (split == NULL)
+		return (NULL);
+	split[len] = NULL;
+	*row = len;
+	return (split);
+}
+
+static char	*ft_strdup_split(char const *src, const char *set)
+{
+	size_t	i;
+	size_t	len;
+	char	*str;
+
+	len = 0;
+	while (!match_check(src[len], set) && src[len])
+		len++;
+	str = (char *)malloc(sizeof(char) * (len + 1));
+	if (str == NULL)
+		return (NULL);
+	i = 0;
+	while (i < len)
+	{
+		str[i] = src[i];
+		i++;
+	}
+	str[i] = '\0';
+	return (str);
+}
+
+static char	**free_split(char **split)
+{
+	size_t	i;
+
+	i = 0;
+	while (split[i])
+	{
+		free(split[i]);
+		i++;
+	}
+	free(split);
+	return (NULL);
+}
+
+char	**word_split(char const *str, const char *set)
+{
+	size_t	i;
+	size_t	j;
+	size_t	row;
+	char	**split;
+
+	if (!str)
+		return (NULL);
+	i = 0;
+	j = 0;
+	split = row_malloc_split(str, set, &row);
+	if (split == NULL)
+		return (NULL);
+	while (i < row)
+	{
+		while (match_check(str[j], set))
+			j++;
+		split[i] = ft_strdup_split(&str[j], set);
+		if (split[i] == NULL)
+			return (free_split(split));
+		i++;
+		while (!match_check(str[j], set) && str[j])
+			j++;
+	}
+	return (split);
+}

--- a/expander/test/expansion_test.c
+++ b/expander/test/expansion_test.c
@@ -71,7 +71,8 @@ int main(int ac, char **av, char **envp) {
 		setenv("TEST", "echo hello", 1);
 		char input[] = "$TEST";
 		t_test expected[] = {
-				{COMMAND_ARG_NODE, "echo hello"},
+				{COMMAND_ARG_NODE, "echo"},
+				{COMMAND_ARG_NODE, "hello"},
 		};
 		test_expander(input, expected, ENV_VARS, environ);
 	}
@@ -139,7 +140,8 @@ int main(int ac, char **av, char **envp) {
 		char input[] = "echo exp*.c";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "echo"},
-				{COMMAND_ARG_NODE, "expansion_test.c expansion_wildcard_test.c"},
+				{COMMAND_ARG_NODE, "expansion_test.c"},
+				{COMMAND_ARG_NODE, "expansion_wildcard_test.c"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
 	}
@@ -147,7 +149,8 @@ int main(int ac, char **av, char **envp) {
 		char input[] = "echo *.c";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "echo"},
-				{COMMAND_ARG_NODE, "expansion_test.c expansion_wildcard_test.c"},
+				{COMMAND_ARG_NODE, "expansion_test.c"},
+				{COMMAND_ARG_NODE, "expansion_wildcard_test.c"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
 	}
@@ -155,7 +158,8 @@ int main(int ac, char **av, char **envp) {
 		char input[] = "echo expa*";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "echo"},
-				{COMMAND_ARG_NODE, "expansion_test.c expansion_wildcard_test.c"},
+				{COMMAND_ARG_NODE, "expansion_test.c"},
+				{COMMAND_ARG_NODE, "expansion_wildcard_test.c"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
 	}
@@ -163,7 +167,8 @@ int main(int ac, char **av, char **envp) {
 		char input[] = "echo \"ex\"p*.\'c\'";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "echo"},
-				{COMMAND_ARG_NODE, "expansion_test.c expansion_wildcard_test.c"},
+				{COMMAND_ARG_NODE, "expansion_test.c"},
+				{COMMAND_ARG_NODE, "expansion_wildcard_test.c"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
 	}
@@ -171,7 +176,11 @@ int main(int ac, char **av, char **envp) {
 		char input[] = "echo *";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "echo"},
-				{COMMAND_ARG_NODE, "Makefile a.out expansion_test.c expansion_wildcard_test.c obj"},
+				{COMMAND_ARG_NODE, "Makefile"},
+				{COMMAND_ARG_NODE, "a.out"},
+				{COMMAND_ARG_NODE, "expansion_test.c"},
+				{COMMAND_ARG_NODE, "expansion_wildcard_test.c"},
+				{COMMAND_ARG_NODE, "obj"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
 	}
@@ -182,6 +191,24 @@ int main(int ac, char **av, char **envp) {
 				{COMMAND_ARG_NODE, "obj"},
 		};
 		test_expander(input, expected, WILDCARD, environ);
+	}
+	{
+		char input[] = "\"echo hello\"";
+		t_test expected[] = {
+				{COMMAND_ARG_NODE, "\"echo hello\""},
+				{COMMAND_ARG_NODE, "error"},
+		};
+		test_expander(input, expected, WORD_SPLIT, environ);
+	}
+	{
+		setenv("TEST", "echo hello", 1);
+		char input[] = "\"ls -l\"$TEST";
+		t_test expected[] = {
+				{COMMAND_ARG_NODE, "\"ls -l\"echo"},
+				{COMMAND_ARG_NODE, "hello"},
+				{COMMAND_ARG_NODE, "error"},
+		};
+		test_expander(input, expected, WORD_SPLIT, environ);
 	}
 }
 


### PR DESCRIPTION
- Fix: prototype declare filename
- Add: basic word splitting

## Purpose
expansionの`word splitting`を実装
`",'`などが混じった場合はまだ実装できてません；；

## Effect
wildcard処理後、`test.c main.c`みたいな文字列が来た時に、空白ごとに文字列を分解して、複数の`t_ast_node`に枝分かれするようにした。


## Memo
`t_ast_node`のlevelや枝の繋がってる位置(`left, right`)など、間違ってないか確認お願いします！
