### PR TITLE
builtinの`cd`コマンドを実装

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -1,8 +1,11 @@
-//
-// Created by Takumi Hara on 2021/10/05.
-//
+#ifndef BUILTIN_H
+#define BUILTIN_H
 
-#ifndef MINISHELL_BUILTIN_H
-#define MINISHELL_BUILTIN_H
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../../libft/libft.h"
 
-#endif //MINISHELL_BUILTIN_H
+void	cd(int argc, char **argv);
+
+#endif //BUILTIN_H

--- a/builtin/cd.c
+++ b/builtin/cd.c
@@ -1,6 +1,16 @@
+#include <string.h>
 #include "builtin.h"
+#include "../libft/libft.h"
 
 void	cd(int argc, char **argv)
 {
-
+	char	*path;
+	if (argc == 1)
+		path = getenv("HOME");
+	else if (ft_strlen(argv[1]) == 0)
+		return ;
+	else
+		path = argv[1];
+	if (chdir(path) == -1)
+		perror("chdir");
 }

--- a/builtin/cd.c
+++ b/builtin/cd.c
@@ -6,11 +6,18 @@ void	cd(int argc, char **argv)
 {
 	char	*path;
 	if (argc == 1)
+	{
 		path = getenv("HOME");
-	else if (ft_strlen(argv[1]) == 0)
+		if (!path)
+		{
+			ft_putendl_fd("minishell: cd: HOME not set", 2);
+			return ;
+		}
+	}
+	else if (argv[1][0] == '\0')
 		return ;
 	else
 		path = argv[1];
 	if (chdir(path) == -1)
-		perror("chdir");
+		perror("minishell: cd");
 }

--- a/builtin/test/Makefile
+++ b/builtin/test/Makefile
@@ -1,0 +1,66 @@
+NAME = a.out
+
+BUILTIN_PATH= ..
+PARSER_PATH	= ../../parser
+LEXER_PATH	= ../../lexer
+AST_PATH	= ../../ast
+UTILS_PATH	= ../../utils
+SRC_PATHS	= . $(BUILTIN_PATH) $(PARSER_PATH) $(LEXER_PATH) $(AST_PATH) $(UTILS_PATH)
+SRCS		= $(foreach path, $(SRC_PATHS), $(wildcard $(path)/*.c))
+
+OBJDIR  = ./obj
+OBJS    = $(addprefix $(OBJDIR)/, $(notdir $(SRCS:%.c=%.o)))
+
+CC		= gcc
+CFLAG	= -Wall -Wextra -Werror -fsanitize=address -DTEST
+
+LIBFT_PATH = ../../libft
+#INCLUDE		= -I../../lexer -I../../token -I../../ast -I../../parser
+
+#all: $(NAME)
+all: run
+
+$(NAME): $(OBJS)
+	@make -C $(LIBFT_PATH)
+	$(CC) $(CFLAG) $(INCLUDE) $^ -o $@ -L$(LIBFT_PATH) -lft
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+$(OBJDIR)/%.o: $(PARSER_PATH)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+$(OBJDIR)/%.o: $(LEXER_PATH)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+$(OBJDIR)/%.o: $(AST_PATH)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+$(OBJDIR)/%.o: $(UTILS_PATH)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+$(OBJDIR)/%.o: $(BUILTIN_PATH)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAG) -o $@ -c $<
+
+clean:
+	@make fclean -C $(LIBFT_PATH)
+	$(RM) -r $(OBJDIR)
+	$(RM) -r $(PARSER_OBJDIR)
+	$(RM) -r $(LEXER_OBJDIR)
+
+fclean: clean
+	@make fclean -C $(LIBFT_PATH)
+	$(RM) $(NAME)
+
+re: fclean all
+
+run: $(NAME)
+	./$(NAME)
+
+.PHONY: all re clean fclean run

--- a/builtin/test/builtin_test.c
+++ b/builtin/test/builtin_test.c
@@ -1,0 +1,61 @@
+#include <stdlib.h>
+#include <string.h>
+#include "../../utils/utils.h"
+#include "../builtin.h"
+
+#define RESET   "\033[0m"
+#define RED     "\033[31m"      /* Red */
+#define BLUE    "\033[34m"      /* Blue */
+
+void test_cd(char *expected_path, int argc, char *arg1, char *arg2, char *arg3);
+
+int main() {
+	// test cd
+	{
+		test_cd("/obj", 2, "obj", NULL, NULL);
+	}
+	{
+		test_cd("", 2, "", NULL, NULL);
+	}
+	{
+		test_cd("", 2, ".", NULL, NULL);
+	}
+	{
+		test_cd("/obj", 3, "obj", "a", NULL);
+	}
+	{
+		test_cd("/obj", 4, "obj", "a", "b");
+	}
+	{
+		test_cd(NULL, 1, NULL, NULL, NULL);
+	}
+}
+
+
+void test_cd(char *expected_path, int argc, char *arg1, char *arg2, char *arg3) {
+	printf("\n---------------------------------\n");
+	printf("	 [cd] TEST\n");
+	printf("---------------------------------\n");
+	char **argv = malloc(sizeof(*argv) * 4);
+	argv[0] = "cd";
+	argv[1] = (arg1) ? arg1 : NULL;
+	argv[2] = (arg1) ? arg2 : NULL;
+	argv[3] = (arg1) ? arg3 : NULL;
+	char *cwd = getcwd(NULL, 0);
+	char *start_wd = getcwd(NULL, 0);
+	cd(argc, argv);
+	if (expected_path)
+		expected_path = strappend(cwd, expected_path, strlen(expected_path));
+	else
+		expected_path = strdup(getenv("HOME"));
+	cwd = getcwd(NULL, 0);
+	if (strcmp(cwd, expected_path) != 0)
+		printf(RED "cd wrong! expected=%s got=%s\n" RESET, expected_path, cwd);
+	else
+		printf("success!\n");
+	chdir(start_wd);
+	free(argv);
+	free(expected_path);
+	free(cwd);
+	free(start_wd);
+}


### PR DESCRIPTION
## Purpose

実装・テストが問題ないかレビュー

## Effect

`execution`でbuiltinコマンドが使えるようになり、`subshell`の挙動確認がしやすくなる

## Test

```
$ cd /minishell/builtin/test
$ make
```
