### PR TITLE
`t_expander`構造体を定義し、各種エラー処理を追加

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -1,53 +1,55 @@
 #include "expander.h"
 
-void		search_command_arg_node(t_ast_node *node);
-char		*expand_word(char *data, char delimiter, char *(*f)(char *, size_t));
+void		search_command_arg_node(t_expander *e);
+char		*expand_word(t_expander *e, char delimiter, char *(*f)(char *, size_t, t_expander *));
 char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
 char		*expand_environment_variable(char *data, size_t replace_starts);
 char		*expand_wildcard(char *data, size_t pre_len);
 t_ast_node	*word_splitting(t_ast_node *node);
 
-t_ast_node	*expand(t_ast_node *node, char **envp)
+t_ast_node	*expand(t_ast_node *root, char **environ)
 {
-	t_ast_node	*root;
-	// t_env_var	*vars;
+	t_expander	*e;
 
-	(void)envp;
-	// vars = split_environment_vars(envp);
-	// if (!vars)
-	// 	return (NULL);
-	// todo: remove this. To confirm env list.
-	// print_env_lst(vars);
-	root = node;
-	search_command_arg_node(node);
+	(void)environ;
+	if (!root)
+		return (NULL);
+	if (!new_expander(&e, root))
+		return (ex_perror(NULL, "malloc"));
+	search_command_arg_node(e);
 	// env_lstclear(vars);
+	free(e);
 	return (root);
 }
 
-void	search_command_arg_node(t_ast_node *node)
+void	search_command_arg_node(t_expander *e)
 {
-	if (!node)
+	if (!e->node)
 		return ;
-	search_command_arg_node(node->right);
-	search_command_arg_node(node->left);
+	e->node = e->node->right;
+	search_command_arg_node(e);
+	e->node = e->node->left;
+	search_command_arg_node(e);
 	if (node->type != COMMAND_ARG_NODE)
 		return ;
 	// todo: export env_var
 	// if (!ft_strcmp(node->data, "export"))
 	// 	export_env_var();
-	node->data = expand_word(node->data, '$', &expand_environment_variable);
-	node->data = expand_word(node->data, '*', &expand_wildcard);
-	node = word_splitting(node);
+	e->node->data = expand_word(e, '$', &expand_environment_variable);
+	e->node->data = expand_word(e, '*', &expand_wildcard);
+	e->node = word_splitting(node);
 	// todo: remove quotes
 	// data = remove_quotes();
 }
 
-char	*expand_word(char *data, char delimiter, char *(*f)(char *, size_t))
+char	*expand_word(t_expander *e, char delimiter, char *(*f)(char *, size_t, t_expander *))
 {
+	char	*data;
 	size_t	i;
 	size_t	double_quote;
 	size_t	single_quote;
 
+	data = e->node->data;
 	if (!data)
 		return (NULL);
 	if (!is_expandable_string(data, delimiter))
@@ -62,7 +64,7 @@ char	*expand_word(char *data, char delimiter, char *(*f)(char *, size_t))
 		else if (data[i] == '\'' && double_quote % 2 == 0)
 			single_quote++;
 		else if (data[i] == delimiter && single_quote % 2 == 0)
-			data = f(data, i);
+			data = f(data, i, e);
 		if (!data)
 			return (NULL);
 		if (!data[i])
@@ -73,7 +75,7 @@ char	*expand_word(char *data, char delimiter, char *(*f)(char *, size_t))
 }
 
 // todo: $? expands exit status
-char	*expand_environment_variable(char *data, size_t replace_start)
+char	*expand_environment_variable(char *data, size_t replace_start, t_expander *e)
 {
 	const char		*var_start = &data[replace_start + 1];
 	const size_t	var_len = var_strlen(var_start);
@@ -82,7 +84,7 @@ char	*expand_environment_variable(char *data, size_t replace_start)
 
 	key = malloc(sizeof(char) * (var_len + 1));
 	if (!key)
-		return (NULL);
+		return (ex_perror());
 	ft_memmove(key, var_start, var_len);
 	key[var_len] = '\0';
 	value = getenv(key);
@@ -93,7 +95,7 @@ char	*expand_environment_variable(char *data, size_t replace_start)
 		return (str_insert(data, replace_start, "", 0));
 }
 
-char	*expand_wildcard(char *data, size_t pre_len)
+char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 {
 	DIR				*dir;
 	struct dirent	*dp;

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -1,11 +1,11 @@
 #include "expander.h"
 
-void		search_command_arg_node(t_expander *e);
+void		search_command_arg_node(t_expander *e, t_ast_node *node);
 char		*expand_word(t_expander *e, char delimiter, char *(*f)(char *, size_t, t_expander *));
 char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
-char		*expand_environment_variable(char *data, size_t replace_starts);
-char		*expand_wildcard(char *data, size_t pre_len);
-t_ast_node	*word_splitting(t_ast_node *node);
+char		*expand_environment_variable(char *data, size_t replace_starts, t_expander *e);
+char		*expand_wildcard(char *data, size_t pre_len, t_expander *e);
+t_ast_node	*word_splitting(t_ast_node *node, t_expander *e);
 
 t_ast_node	*expand(t_ast_node *root, char **environ)
 {
@@ -15,29 +15,27 @@ t_ast_node	*expand(t_ast_node *root, char **environ)
 	if (!root)
 		return (NULL);
 	if (!new_expander(&e, root))
-		return (ex_perror(NULL, "malloc"));
-	search_command_arg_node(e);
-	// env_lstclear(vars);
+		exit(expand_perror(NULL, "malloc"));
+	search_command_arg_node(e, root);
 	free(e);
 	return (root);
 }
 
-void	search_command_arg_node(t_expander *e)
+void	search_command_arg_node(t_expander *e, t_ast_node *node)
 {
-	if (!e->node)
+	if (!node)
 		return ;
-	e->node = e->node->right;
-	search_command_arg_node(e);
-	e->node = e->node->left;
-	search_command_arg_node(e);
+	search_command_arg_node(e, node->right);
+	search_command_arg_node(e, node->left);
 	if (node->type != COMMAND_ARG_NODE)
 		return ;
+	e->node = node;
 	// todo: export env_var
 	// if (!ft_strcmp(node->data, "export"))
 	// 	export_env_var();
-	e->node->data = expand_word(e, '$', &expand_environment_variable);
-	e->node->data = expand_word(e, '*', &expand_wildcard);
-	e->node = word_splitting(node);
+	node->data = expand_word(e, '$', &expand_environment_variable);
+	node->data = expand_word(e, '*', &expand_wildcard);
+	node = word_splitting(node, e);
 	// todo: remove quotes
 	// data = remove_quotes();
 }
@@ -50,6 +48,7 @@ char	*expand_word(t_expander *e, char delimiter, char *(*f)(char *, size_t, t_ex
 	size_t	single_quote;
 
 	data = e->node->data;
+	printf("%s\n", data);
 	if (!data)
 		return (NULL);
 	if (!is_expandable_string(data, delimiter))
@@ -84,7 +83,7 @@ char	*expand_environment_variable(char *data, size_t replace_start, t_expander *
 
 	key = malloc(sizeof(char) * (var_len + 1));
 	if (!key)
-		return (ex_perror());
+		exit(expand_perror(e, "malloc"));
 	ft_memmove(key, var_start, var_len);
 	key[var_len] = '\0';
 	value = getenv(key);
@@ -105,7 +104,7 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 
 	dir = opendir(".");
 	if (!dir)
-		return (NULL);
+		exit(expand_perror(e, "opendir"));
 	rtn = data;
 	while (1)
 	{
@@ -116,18 +115,18 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 			continue ;
 		if (is_match_pattern(rtn, pre_len, dp->d_name)
 			&& is_match_pattern(post_start, post_len, ft_strchr(dp->d_name, 0) - post_len))
-			rtn = append_wildcard_strings(rtn, dp->d_name, data);
+			rtn = append_wildcard_strings(rtn, dp->d_name, data, e);
 	}
 	closedir(dir);
 	if (rtn != data)
 	{
 		free(data);
-		rtn = sort_strings(rtn);
+		rtn = sort_strings(rtn, e);
 	}
 	return (rtn);
 }
 
-t_ast_node	*word_splitting(t_ast_node *node)
+t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 {
 	char		**split;
 	size_t		i;
@@ -138,9 +137,9 @@ t_ast_node	*word_splitting(t_ast_node *node)
 		return (NULL);
 	if (!*node->data)
 		return (node);
-	split = word_split(node->data, " \t\n");
+	split = split_by_delims(node->data, " \t\n");
 	if (!split)
-		return (NULL);
+		exit(expand_perror(e, "malloc"));
 	free(node->data);
 	i = 0;
 	root = node;
@@ -151,7 +150,7 @@ t_ast_node	*word_splitting(t_ast_node *node)
 		else
 		{
 			if (!new_ast_node(&result))
-				return (delete_ast_nodes(node, NULL));
+				exit(expand_perror(e, "malloc"));
 			result->data = split[i];
 			result->type = COMMAND_ARG_NODE;
 			node->right = result;

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -1,47 +1,48 @@
 #include "expander.h"
 
-void		search_command_arg_node(t_ast_node *node, t_env_var *vars);
-char		*expand_word(char *data, t_env_var *vars, char delimiter, char *(*f)(char *, size_t, t_env_var *));
-char		*expand_quotes_string(char *data, size_t replace_start, t_env_var *vars, char quote_type);
-char		*expand_environment_variable(char *data, size_t replace_start, t_env_var *vars);
-char		*expand_wildcard(char *data, size_t pre_len, t_env_var *vars);
+void		search_command_arg_node(t_ast_node *node);
+char		*expand_word(char *data, char delimiter, char *(*f)(char *, size_t));
+char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
+char		*expand_environment_variable(char *data, size_t replace_starts);
+char		*expand_wildcard(char *data, size_t pre_len);
 t_ast_node	*word_splitting(t_ast_node *node);
 
 t_ast_node	*expand(t_ast_node *node, char **envp)
 {
 	t_ast_node	*root;
-	t_env_var	*vars;
+	// t_env_var	*vars;
 
-	vars = split_environment_vars(envp);
-	if (!vars)
-		return (NULL);
+	(void)envp;
+	// vars = split_environment_vars(envp);
+	// if (!vars)
+	// 	return (NULL);
 	// todo: remove this. To confirm env list.
 	// print_env_lst(vars);
 	root = node;
-	search_command_arg_node(node, vars);
-	env_lstclear(vars);
+	search_command_arg_node(node);
+	// env_lstclear(vars);
 	return (root);
 }
 
-void	search_command_arg_node(t_ast_node *node, t_env_var *vars)
+void	search_command_arg_node(t_ast_node *node)
 {
 	if (!node)
 		return ;
-	search_command_arg_node(node->right, vars);
-	search_command_arg_node(node->left, vars);
+	search_command_arg_node(node->right);
+	search_command_arg_node(node->left);
 	if (node->type != COMMAND_ARG_NODE)
 		return ;
 	// todo: export env_var
 	// if (!ft_strcmp(node->data, "export"))
 	// 	export_env_var();
-	node->data = expand_word(node->data, vars, '$', &expand_environment_variable);
-	node->data = expand_word(node->data, vars, '*', &expand_wildcard);
+	node->data = expand_word(node->data, '$', &expand_environment_variable);
+	node->data = expand_word(node->data, '*', &expand_wildcard);
 	node = word_splitting(node);
 	// todo: remove quotes
 	// data = remove_quotes();
 }
 
-char	*expand_word(char *data, t_env_var *vars, char delimiter, char *(*f)(char *, size_t, t_env_var *))
+char	*expand_word(char *data, char delimiter, char *(*f)(char *, size_t))
 {
 	size_t	i;
 	size_t	double_quote;
@@ -61,7 +62,7 @@ char	*expand_word(char *data, t_env_var *vars, char delimiter, char *(*f)(char *
 		else if (data[i] == '\'' && double_quote % 2 == 0)
 			single_quote++;
 		else if (data[i] == delimiter && single_quote % 2 == 0)
-			data = f(data, i, vars);
+			data = f(data, i);
 		if (!data)
 			return (NULL);
 		if (!data[i])
@@ -72,18 +73,27 @@ char	*expand_word(char *data, t_env_var *vars, char delimiter, char *(*f)(char *
 }
 
 // todo: $? expands exit status
-char	*expand_environment_variable(char *data, size_t replace_start, t_env_var *vars)
+char	*expand_environment_variable(char *data, size_t replace_start)
 {
-	char	*env_value;
+	const char		*var_start = &data[replace_start + 1];
+	const size_t	var_len = var_strlen(var_start);
+	char			*key;
+	char			*value;
 
-	env_value = search_env_vars(data, replace_start + 1, vars);
-	if (env_value)
-		return (str_insert(data, replace_start, env_value, ft_strlen(env_value)));
+	key = malloc(sizeof(char) * (var_len + 1));
+	if (!key)
+		return (NULL);
+	ft_memmove(key, var_start, var_len);
+	key[var_len] = '\0';
+	value = getenv(key);
+	free(key);
+	if (value)
+		return (str_insert(data, replace_start, value, ft_strlen(value)));
 	else
 		return (str_insert(data, replace_start, "", 0));
 }
 
-char	*expand_wildcard(char *data, size_t pre_len, t_env_var *vars)
+char	*expand_wildcard(char *data, size_t pre_len)
 {
 	DIR				*dir;
 	struct dirent	*dp;
@@ -91,7 +101,6 @@ char	*expand_wildcard(char *data, size_t pre_len, t_env_var *vars)
 	const size_t	post_len = unquoted_strlen(post_start);
 	char			*rtn;
 
-	(void)vars;
 	dir = opendir(".");
 	if (!dir)
 		return (NULL);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -15,16 +15,15 @@
 # define EXPANDABLE "\"\'$"
 # define EXPANSION_DELIMITER "\"\'$|&<>() =\t\n"
 
-typedef struct s_env_var t_env_var;
+typedef struct s_expander t_expander;
 
-struct s_env_var {
-	char		*key;
-	char		*value;
-	t_env_var	*next;
+struct s_expander {
+	t_ast_node	*root;
+	t_ast_node	*node;
 };
 
 // expander.c
-t_ast_node	*expand(t_ast_node *node, char **envp);
+t_ast_node	*expand(t_ast_node *root, char **envp);
 
 // expander_utils.c
 bool		is_expandable_string(char *str, char delimiter);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -30,16 +30,16 @@ t_ast_node	*expand(t_ast_node *node, char **envp);
 bool		is_expandable_string(char *str, char delimiter);
 
 // expander_env.c
-size_t		var_len(const char *str);	
-char		*search_env_vars(char *data, size_t var_start, t_env_var *vars);
+size_t		var_strlen(const char *str);
+char		*search_env_vars(char *data, size_t var_start);
 char		*str_insert(char *data, size_t replace_start, char *env_value, size_t env_value_len);
 
 // expander_list.c
-t_env_var	*split_environment_vars(char **envp);
-void		env_lstclear(t_env_var *lst);
-void		set_key_value(char *envp, t_env_var *vars);
-// todo: remove this
-void		print_env_lst(t_env_var *vars);
+// t_env_var	*split_environment_vars(char **envp);
+// void		env_lstclear(t_env_var *lst);
+// void		set_key_value(char *envp, t_env_var *vars);
+// // todo: remove this
+// void		print_env_lst(t_env_var *vars);
 
 // expander_wildcard.c
 char		*append_wildcard_strings(char *dst, const char *src, const char *data);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -9,6 +9,7 @@
 # include "../parser/parser.h"
 # include "../libft/libft.h"
 # include "../utils/utils.h"
+# include "../execute/execute.h"
 
 # include <stdlib.h>
 
@@ -26,7 +27,9 @@ struct s_expander {
 t_ast_node	*expand(t_ast_node *root, char **envp);
 
 // expander_utils.c
+bool		new_expander(t_expander **e, t_ast_node *root);
 bool		is_expandable_string(char *str, char delimiter);
+int			expand_perror(t_expander *e, const char *s);
 
 // expander_env.c
 size_t		var_strlen(const char *str);
@@ -41,9 +44,9 @@ char		*str_insert(char *data, size_t replace_start, char *env_value, size_t env_
 // void		print_env_lst(t_env_var *vars);
 
 // expander_wildcard.c
-char		*append_wildcard_strings(char *dst, const char *src, const char *data);
+char		*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e);
 bool		is_match_pattern(const char *data, size_t len, char *name);
-char		*sort_strings(char *src);
+char		*sort_strings(char *src, t_expander *e);
 
 // expander_quote.c
 bool		is_quoted(const char *str);

--- a/expander/expander_env.c
+++ b/expander/expander_env.c
@@ -1,6 +1,6 @@
 #include "expander.h"
 
-size_t	var_len(const char *str)
+size_t	var_strlen(const char *str)
 {
 	size_t	len;
 
@@ -10,23 +10,23 @@ size_t	var_len(const char *str)
 	return (len);
 }
 
-char	*search_env_vars(char *data, size_t var_start, t_env_var *vars)
-{
-	const char		*start = &data[var_start];
-	const size_t	len = var_len(start);
+// char	*search_env_vars(char *data, size_t var_start)
+// {
+// 	const char		*start = &data[var_start];
+// 	const size_t	len = var_len(start);
 
-	while (vars && ft_strncmp(vars->key, start, len))
-		vars = vars->next;
-	if (vars)
-		return (vars->value);
-	else
-		return (NULL);
-}
+// 	while (vars && ft_strncmp(vars->key, start, len))
+// 		vars = vars->next;
+// 	if (vars)
+// 		return (vars->value);
+// 	else
+// 		return (NULL);
+// }
 
 char	*str_insert(char *data, size_t replace_start, char *env_value, size_t env_value_len)
 {
 	const size_t	origin_len = ft_strlen(data);
-	const size_t	env_var_len = var_len(&data[replace_start + 1]) + 1;
+	const size_t	env_var_len = var_strlen(&data[replace_start + 1]) + 1;
 	const size_t	expansion_len = origin_len - env_var_len + env_value_len;
 	char			*prev_data;
 	char			*expanded_str;

--- a/expander/expander_list.c
+++ b/expander/expander_list.c
@@ -1,70 +1,70 @@
-#include "expander.h"
+// #include "expander.h"
 
-t_env_var	*split_environment_vars(char **envp)
-{
-	t_env_var	vars;
-	t_env_var	*tmp;
+// t_env_var	*split_environment_vars(char **envp)
+// {
+// 	t_env_var	vars;
+// 	t_env_var	*tmp;
 
-	vars.next = NULL;
-	tmp = &vars;
-	while (*envp)
-	{
-		tmp->next = (t_env_var *)malloc(sizeof(t_env_var));
-		if (!tmp->next)
-		{
-			env_lstclear(vars.next);
-			return (NULL);
-		}
-		tmp->next->next = NULL;
-		set_key_value(*envp, tmp->next);
-		tmp = tmp->next;
-		envp++;
-	}
-	return (vars.next);
-}
+// 	vars.next = NULL;
+// 	tmp = &vars;
+// 	while (*envp)
+// 	{
+// 		tmp->next = (t_env_var *)malloc(sizeof(t_env_var));
+// 		if (!tmp->next)
+// 		{
+// 			env_lstclear(vars.next);
+// 			return (NULL);
+// 		}
+// 		tmp->next->next = NULL;
+// 		set_key_value(*envp, tmp->next);
+// 		tmp = tmp->next;
+// 		envp++;
+// 	}
+// 	return (vars.next);
+// }
 
-void		set_key_value(char *envp, t_env_var *vars)
-{
-	size_t	len;
+// void		set_key_value(char *envp, t_env_var *vars)
+// {
+// 	size_t	len;
 
-	len = 0;
-	vars->key = envp;
-	while (envp[len])
-	{
-		if (envp[len] == '=')
-		{
-			vars->value = &envp[len + 1];
-			return ;
-		}
-		len++;
-	}
-}
+// 	len = 0;
+// 	vars->key = envp;
+// 	while (envp[len])
+// 	{
+// 		if (envp[len] == '=')
+// 		{
+// 			vars->value = &envp[len + 1];
+// 			return ;
+// 		}
+// 		len++;
+// 	}
+// }
 
-void	env_lstclear(t_env_var *lst)
-{
-	t_env_var	*tmp;
+// void	env_lstclear(t_env_var *lst)
+// {
+// 	t_env_var	*tmp;
 
-	if (!lst)
-		return ;
-	while (lst)
-	{
-		tmp = lst->next;
-		free(lst);
-		lst = tmp;
-	}
-}
+// 	if (!lst)
+// 		return ;
+// 	while (lst)
+// 	{
+// 		tmp = lst->next;
+// 		free(lst);
+// 		lst = tmp;
+// 	}
+// }
 
-// todo: remove test function.
-void	print_env_lst(t_env_var *vars)
-{
-	size_t	i = 0;
+// // todo: remove test function.
+// void	print_env_lst(t_env_var *vars)
+// {
+// 	size_t	i = 0;
 
-	while (vars)
-	{
-		printf("index :[%zu]\n", i);
-		printf("key :%s\n", vars->key);
-		printf("value :%s\n\n", vars->value);
-		i++;
-		vars = vars->next;
-	}
-}
+// 	while (vars)
+// 	{
+// 		printf("index :[%zu]\n", i);
+// 		printf("key :%s\n", vars->key);
+// 		printf("value :%s\n\n", vars->value);
+// 		i++;
+// 		vars = vars->next;
+// 	}
+// }

--- a/expander/expander_splitting.c
+++ b/expander/expander_splitting.c
@@ -1,6 +1,6 @@
 #include "expander.h"
 
-static bool	match_check(char c, char const *set)
+static bool	is_set(char c, char const *set)
 {
 	size_t	j;
 
@@ -24,9 +24,9 @@ static char	**row_malloc_split(char const *str, const char *set, size_t *row)
 	len = 0;
 	while (str[i])
 	{
-		if (!match_check(str[i], set))
+		if (!is_set(str[i], set))
 		{
-			while (!match_check(str[i], set) && str[i])
+			while (!is_set(str[i], set) && str[i])
 				i++;
 			len++;
 		}
@@ -49,7 +49,7 @@ static char	*ft_strdup_split(char const *src, const char *set)
 	char	*str;
 
 	len = 0;
-	while (!match_check(src[len], set) && src[len])
+	while (!is_set(src[len], set) && src[len])
 		len++;
 	str = (char *)malloc(sizeof(char) * (len + 1));
 	if (str == NULL)
@@ -94,13 +94,13 @@ char	**word_split(char const *str, const char *set)
 		return (NULL);
 	while (i < row)
 	{
-		while (match_check(str[j], set))
+		while (is_set(str[j], set))
 			j++;
 		split[i] = ft_strdup_split(&str[j], set);
 		if (split[i] == NULL)
 			return (free_split(split));
 		i++;
-		while (!match_check(str[j], set) && str[j])
+		while (!is_set(str[j], set) && str[j])
 			j++;
 	}
 	return (split);

--- a/expander/expander_utils.c
+++ b/expander/expander_utils.c
@@ -16,3 +16,14 @@ bool	is_expandable_string(char *str, char delimiter)
 		return (true);
 	return (false);
 }
+
+int	expand_perror(t_expander *e, const char *s)
+{
+	perror(s);
+	if (e)
+	{
+		delete_ast_nodes(e->root, NULL);
+	}
+	free(e);
+	return (EXIT_FAILURE);
+}

--- a/expander/expander_utils.c
+++ b/expander/expander_utils.c
@@ -1,5 +1,15 @@
 #include "expander.h"
 
+bool	new_expander(t_expander **e, t_ast_node *root)
+{
+	*e = (t_expander *)malloc(sizeof(**e));
+	if (!*e)
+		return (false);
+	(*e)->root = root;
+	(*e)->node = root;
+	return (true);
+}
+
 bool	is_expandable_string(char *str, char delimiter)
 {
 	if (ft_strchr(str, delimiter))

--- a/expander/expander_wildcard.c
+++ b/expander/expander_wildcard.c
@@ -1,6 +1,6 @@
 #include "expander.h"
 
-char	*append_wildcard_strings(char *dst, const char *src, const char *data)
+char	*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e)
 {
 	if (dst == data)
 		return (ft_strdup(src));
@@ -8,7 +8,10 @@ char	*append_wildcard_strings(char *dst, const char *src, const char *data)
 	{
 		dst = strappend(dst, " ", 1);
 		if (!dst)
-			return (NULL);
+		{
+			free(src);
+			exit(expand_perror(e, "malloc"));
+		}
 		dst = strappend(dst, src, ft_strlen(src));
 		return (dst);
 	}
@@ -71,7 +74,7 @@ static void	quick_sort(char **array, size_t left, size_t right)
 		quick_sort(array, j + 1, right);
 }
 
-char	*sort_strings(char *src)
+char	*sort_strings(char *src, t_expander *e)
 {
 	char	**wildcard_array;
 	size_t	word_num;
@@ -79,9 +82,9 @@ char	*sort_strings(char *src)
 	size_t	i;
 
 	wildcard_array = ft_split(src, ' ');
-	if (!wildcard_array)
-		return (NULL);
 	free(src);
+	if (!wildcard_array)
+		exit(expand_perror(e, "malloc"));
 	word_num = 0;
 	while (wildcard_array[word_num])
 		word_num++;
@@ -89,7 +92,7 @@ char	*sort_strings(char *src)
 	rtn = NULL;
 	i = 0;
 	while (i < word_num)
-		rtn = append_wildcard_strings(rtn, wildcard_array[i++], NULL);
+		rtn = append_wildcard_strings(rtn, wildcard_array[i++], NULL, e);
 	free_2d_array((void ***)&wildcard_array);
 	return (rtn);
 }

--- a/expander/test/expansion_test.c
+++ b/expander/test/expansion_test.c
@@ -35,10 +35,9 @@ int err_cnt;
 
 extern char	**environ;
 
-int main(int ac, char **av, char **envp) {
+int main(int ac, char **av) {
 	(void)ac;
 	(void)av;
-	(void)envp;
 	{
 		if (setenv("TEST", "hello", 1) != 0)
 			perror("setenv");

--- a/utils/split_by_delims.c
+++ b/utils/split_by_delims.c
@@ -1,20 +1,20 @@
-#include "expander.h"
+#include "utils.h"
 
-static bool	is_set(char c, char const *set)
+static bool	is_delims(char c, char const *delims)
 {
 	size_t	j;
 
 	j = 0;
-	while (set[j])
+	while (delims[j])
 	{
-		if (set[j] == c)
+		if (delims[j] == c)
 			return (true);
 		j++;
 	}
 	return (false);
 }
 
-static char	**row_malloc_split(char const *str, const char *set, size_t *row)
+static char	**row_malloc_split(char const *str, const char *delims, size_t *row)
 {
 	size_t	len;
 	size_t	i;
@@ -24,9 +24,9 @@ static char	**row_malloc_split(char const *str, const char *set, size_t *row)
 	len = 0;
 	while (str[i])
 	{
-		if (!is_set(str[i], set))
+		if (!is_delims(str[i], delims))
 		{
-			while (!is_set(str[i], set) && str[i])
+			while (!is_delims(str[i], delims) && str[i])
 				i++;
 			len++;
 		}
@@ -42,14 +42,14 @@ static char	**row_malloc_split(char const *str, const char *set, size_t *row)
 	return (split);
 }
 
-static char	*ft_strdup_split(char const *src, const char *set)
+static char	*ft_strdup_split(char const *src, const char *delims)
 {
 	size_t	i;
 	size_t	len;
 	char	*str;
 
 	len = 0;
-	while (!is_set(src[len], set) && src[len])
+	while (!is_delims(src[len], delims) && src[len])
 		len++;
 	str = (char *)malloc(sizeof(char) * (len + 1));
 	if (str == NULL)
@@ -78,7 +78,7 @@ static char	**free_split(char **split)
 	return (NULL);
 }
 
-char	**word_split(char const *str, const char *set)
+char	**split_by_delims(char const *str, const char *delims)
 {
 	size_t	i;
 	size_t	j;
@@ -89,18 +89,18 @@ char	**word_split(char const *str, const char *set)
 		return (NULL);
 	i = 0;
 	j = 0;
-	split = row_malloc_split(str, set, &row);
+	split = row_malloc_split(str, delims, &row);
 	if (split == NULL)
 		return (NULL);
 	while (i < row)
 	{
-		while (is_set(str[j], set))
+		while (is_delims(str[j], delims))
 			j++;
-		split[i] = ft_strdup_split(&str[j], set);
+		split[i] = ft_strdup_split(&str[j], delims);
 		if (split[i] == NULL)
 			return (free_split(split));
 		i++;
-		while (!is_set(str[j], set) && str[j])
+		while (!is_delims(str[j], delims) && str[j])
 			j++;
 	}
 	return (split);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -9,5 +9,6 @@ bool	assign_mem(void **dst, void *src);
 char	*strappend(char *dst, const char *src, size_t l);
 char	*strldup(const char *str, size_t size);
 void	free_2d_array(void ***array);
+char	**split_by_delims(char const *str, const char *delims);
 
 # endif //UTILS_H


### PR DESCRIPTION
- Update: env_lst to getenv
- Add: t_expander
- Add: t_expander to handle error

## Purpose
`malloc`でエラーが起きた際に、AST全てを`free`する必要が亜あるため、`t_expander`構造体にASTのrootを持たせて対応した（できてると思う）

## Effect
- 環境変数をリストではなく、`getenv()`で取得するようにしました！
- エラーが起きた時に、`delete_ast_nodes()`で`free`できるようになったはず！（あざす）


## Memo
