### PR TITLE
`exit_status`周りの修正

### DIFF
--- a/execute/execute.h
+++ b/execute/execute.h
@@ -20,8 +20,10 @@
 # define READ 0
 # define WRITE 1
 
-# define CHILD_PROCESS_CREATED (-1)
-# define NOT_BUILTIN (-1)
+# define CHILD_PROCESS 0
+
+# define CHILD_PROCESS_NOT_CREATED 0
+# define NOT_LAST_COMMAND 0
 
 typedef struct s_pipeline		t_pipeline;
 typedef struct s_subshell		t_subshell;
@@ -109,7 +111,7 @@ bool	new_argv(t_simple_command *sc);
 bool	new_executor(t_executor **e, t_ast_node *root);
 int		ex_perror(t_executor *e, const char *s);
 void	delete_list(void *element, t_list_type type);
-int		execute_builtin(int argc, char **argv);
+bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast);
 bool	is_execute_condition(int condition, int exit_status);
 
 // new_redirect.c

--- a/execute/execute.h
+++ b/execute/execute.h
@@ -10,9 +10,6 @@
 # include "../libft/libft.h"
 # include "../builtin/builtin.h"
 
-# define SUCCESS 0
-# define FAILURE 1
-
 # define CONDITION_AND_IF 0
 # define CONDITION_OR_IF 1
 # define CONDITION_NL 2
@@ -113,6 +110,7 @@ bool	new_executor(t_executor **e, t_ast_node *root);
 int		ex_perror(t_executor *e, const char *s);
 void	delete_list(void *element, t_list_type type);
 int		execute_builtin(int argc, char **argv);
+bool	is_execute_condition(int condition, int exit_status);
 
 // new_redirect.c
 bool	new_t_redirect_out(t_redirect_out **r_out, char *filename, bool append);

--- a/execute/execute_init.c
+++ b/execute/execute_init.c
@@ -24,26 +24,21 @@ int	execute(t_ast_node *root)
 
 int command_line(t_executor *e, t_ast_node *node)
 {
-	if (node->type == AND_IF_NODE)
+	if (node->type == AND_IF_NODE || node->type == OR_IF_NODE)
 	{
-		if (e->exit_status == e->condition)
+		if (is_execute_condition(e->condition, e->exit_status))
 			e->exit_status = execute_pipeline(e, pipeline(e, node->left));
-		e->condition = CONDITION_AND_IF;
-		return (command_line(e, node->right));
-	}
-	else if (node->type == OR_IF_NODE)
-	{
-		if (e->exit_status == e->condition)
-			e->exit_status = execute_pipeline(e, pipeline(e, node->left));
-		e->condition = CONDITION_OR_IF;
+		if (node->type == AND_IF_NODE)
+			e->condition = CONDITION_AND_IF;
+		else if (node->type == OR_IF_NODE)
+			e->condition = CONDITION_OR_IF;
 		return (command_line(e, node->right));
 	}
 	else
 	{
-		if (e->exit_status == e->condition)
-			e->exit_status = execute_pipeline(e, pipeline(e, node));
+		e->exit_status = execute_pipeline(e, pipeline(e, node));
+		return (e->exit_status);
 	}
-	return (e->exit_status);
 }
 
 t_pipeline	*pipeline(t_executor *e, t_ast_node *node)

--- a/execute/execute_init.c
+++ b/execute/execute_init.c
@@ -36,7 +36,8 @@ int command_line(t_executor *e, t_ast_node *node)
 	}
 	else
 	{
-		e->exit_status = execute_pipeline(e, pipeline(e, node));
+		if (is_execute_condition(e->condition, e->exit_status))
+			e->exit_status = execute_pipeline(e, pipeline(e, node));
 		return (e->exit_status);
 	}
 }

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -69,9 +69,9 @@ bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast)
 
 bool	is_execute_condition(int condition, int exit_status)
 {
-	if (condition == CONDITION_AND_IF && exit_status == 0)
+	if (condition == CONDITION_AND_IF && exit_status == EXIT_SUCCESS)
 		return (true);
-	if (condition == CONDITION_OR_IF && exit_status != 0)
+	if (condition == CONDITION_OR_IF && exit_status != EXIT_SUCCESS)
 		return (true);
 	if (condition == CONDITION_NL)
 		return (true);

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -54,18 +54,24 @@ int	ex_perror(t_executor *e, const char *s)
 	return (EXIT_FAILURE);
 }
 
-int	execute_builtin(int argc, char **argv)
+bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast)
 {
 	if (!ft_strcmp(argv[0], "cd"))
-		return (cd(argc, argv));
-	return (NOT_BUILTIN);
+	{
+		if (islast)
+			e->exit_status = cd(argc, argv);
+		else
+			cd(argc, argv);
+		return (true);
+	}
+	return (false);
 }
 
 bool	is_execute_condition(int condition, int exit_status)
 {
 	if (condition == CONDITION_AND_IF && exit_status == 0)
 		return (true);
-	if (condition == CONDITION_AND_IF && exit_status != 0)
+	if (condition == CONDITION_OR_IF && exit_status != 0)
 		return (true);
 	if (condition == CONDITION_NL)
 		return (true);

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -6,7 +6,7 @@ bool	new_executor(t_executor **e, t_ast_node *root)
 	if (!*e)
 		return (false);
 	(*e)->root = root;
-	(*e)->exit_status = SUCCESS;
+	(*e)->exit_status = EXIT_SUCCESS;
 	(*e)->condition = CONDITION_AND_IF;
 	(*e)->pipeline = NULL;
 	return (true);
@@ -59,4 +59,15 @@ int	execute_builtin(int argc, char **argv)
 	if (!ft_strcmp(argv[0], "cd"))
 		return (cd(argc, argv));
 	return (NOT_BUILTIN);
+}
+
+bool	is_execute_condition(int condition, int exit_status)
+{
+	if (condition == CONDITION_AND_IF && exit_status == 0)
+		return (true);
+	if (condition == CONDITION_AND_IF && exit_status != 0)
+		return (true);
+	if (condition == CONDITION_NL)
+		return (true);
+	return (false);
 }

--- a/test/cases/andor.txt
+++ b/test/cases/andor.txt
@@ -1,0 +1,10 @@
+echo hello && echo world
+cat hello && echo world
+echo hello || echo world
+cat hello || echo world
+hello && echo world
+hello && world
+echo hello && echo world
+hello || echo world
+hello || world
+echo hello || echo world

--- a/test/cases/pipe.txt
+++ b/test/cases/pipe.txt
@@ -1,0 +1,8 @@
+ls | cat
+ls | cat | cat
+ls | cat | wc
+ls | ls | ls
+ls | cat | wc
+xxxx | ls | xxxx
+ls | xxxx | ls
+xxxx | yyyy | zzzz


### PR DESCRIPTION
## Purpose

checkin
- 子プロセスの`exit_status`を親プロセスから獲得
- `pipe`で繋がったときの最後の`exit_status`を次の処理に引き継げるようにした
- `and_if`と`or_if`のテストを追加

## Effect

追加分のテストpass！

## Memo
- `subshell`の方の処理は一旦後回しにしてます！