### PR TITLE
`wordsplitting`における`', "`内のスペースを区切りとして認識しない

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -136,7 +136,7 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 		return (NULL);
 	if (!*node->data)
 		return (node);
-	split = split_by_delims_skip_quotes(node->data, " \t\n");
+	split = split_by_space_skip_quotes(node->data, " \t\n");
 	if (!split)
 		exit(expand_perror(e, "malloc"));
 	free(node->data);

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -48,7 +48,6 @@ char	*expand_word(t_expander *e, char delimiter, char *(*f)(char *, size_t, t_ex
 	size_t	single_quote;
 
 	data = e->node->data;
-	printf("%s\n", data);
 	if (!data)
 		return (NULL);
 	if (!is_expandable_string(data, delimiter))
@@ -137,7 +136,7 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 		return (NULL);
 	if (!*node->data)
 		return (node);
-	split = split_by_delims(node->data, " \t\n");
+	split = split_by_delims_skip_quotes(node->data, " \t\n");
 	if (!split)
 		exit(expand_perror(e, "malloc"));
 	free(node->data);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -53,7 +53,7 @@ bool		is_quote(const char c);
 size_t		unquoted_strlen(const char *str);
 
 // expander_splitting.c
-char	**split_by_delims_skip_quotes(char const *str, const char *delims);
+char		**split_by_space_skip_quotes(char const *str, const char *delims);
 
 #endif
 

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -49,11 +49,11 @@ bool		is_match_pattern(const char *data, size_t len, char *name);
 char		*sort_strings(char *src, t_expander *e);
 
 // expander_quote.c
-bool		is_quoted(const char *str);
+bool		is_quote(const char c);
 size_t		unquoted_strlen(const char *str);
 
 // expander_splitting.c
-char	**word_split(char const *s, const char *set);
+char	**split_by_delims_skip_quotes(char const *str, const char *delims);
 
 #endif
 

--- a/expander/expander_quote.c
+++ b/expander/expander_quote.c
@@ -1,8 +1,8 @@
 #include "expander.h"
 
-bool	is_quoted(const char *str)
+bool	is_quote(const char c)
 {
-	return (ft_strchr(str, '\'') || ft_strchr(str, '\"'));
+	return (c == '\'' || c == '\"');
 }
 
 size_t	unquoted_strlen(const char *str)

--- a/expander/expander_wordsplitting.c
+++ b/expander/expander_wordsplitting.c
@@ -60,8 +60,6 @@ static char	*ft_strdup_split(char const *src, const char *delims)
 	char	*str;
 
 	len = 0;
-	// while (!is_delims(src[len], delims) && src[len])
-	// 	len++;
 	while (!is_delims(src[len], delims) && src[len])
 	{
 		if (is_quote(src[len]))
@@ -95,7 +93,7 @@ static char	**free_split(char **split)
 	return (NULL);
 }
 
-char	**split_by_delims_skip_quotes(char const *str, const char *delims)
+char	**split_by_space_skip_quotes(char const *str, const char *delims)
 {
 	size_t	i;
 	size_t	j;

--- a/expander/expnader_wordsplitting.c
+++ b/expander/expnader_wordsplitting.c
@@ -1,0 +1,128 @@
+#include "expander.h"
+
+static bool	is_delims(char c, char const *delims)
+{
+	size_t	j;
+
+	j = 0;
+	while (delims[j])
+	{
+		if (delims[j] == c)
+			return (true);
+		j++;
+	}
+	return (false);
+}
+
+static size_t	skip_quotes(const char *str, char quote_type)
+{
+	size_t	len;
+
+	len = 1;
+	while (str[len] && str[len] != quote_type)
+		len++;
+	return (len);
+}
+
+static char	**row_malloc_split(char const *str, const char *delims, size_t *row)
+{
+	size_t	len;
+	char	**split;
+
+	len = 0;
+	while (*str)
+	{
+		if (!is_delims(*str, delims))
+		{
+			while (!is_delims(*str, delims) && *str)
+			{
+				if (is_quote(*str))
+					str += skip_quotes(str, *str);
+				str++;
+			}
+			len++;
+		}
+		else
+			str++;
+	}
+	split = (char **)malloc(sizeof(char *) * (len + 1));
+	if (split == NULL)
+		return (NULL);
+	split[len] = NULL;
+	*row = len;
+	return (split);
+}
+
+static char	*ft_strdup_split(char const *src, const char *delims)
+{
+	size_t	i;
+	size_t	len;
+	char	*str;
+
+	len = 0;
+	// while (!is_delims(src[len], delims) && src[len])
+	// 	len++;
+	while (!is_delims(src[len], delims) && src[len])
+	{
+		if (is_quote(src[len]))
+			len += skip_quotes(&src[len], src[len]);
+		len++;
+	}
+	str = (char *)malloc(sizeof(char) * (len + 1));
+	if (str == NULL)
+		return (NULL);
+	i = 0;
+	while (i < len)
+	{
+		str[i] = src[i];
+		i++;
+	}
+	str[i] = '\0';
+	return (str);
+}
+
+static char	**free_split(char **split)
+{
+	size_t	i;
+
+	i = 0;
+	while (split[i])
+	{
+		free(split[i]);
+		i++;
+	}
+	free(split);
+	return (NULL);
+}
+
+char	**split_by_delims_skip_quotes(char const *str, const char *delims)
+{
+	size_t	i;
+	size_t	j;
+	size_t	row;
+	char	**split;
+
+	if (!str)
+		return (NULL);
+	i = 0;
+	j = 0;
+	split = row_malloc_split(str, delims, &row);
+	if (split == NULL)
+		return (NULL);
+	while (i < row)
+	{
+		while (is_delims(str[j], delims))
+			j++;
+		split[i] = ft_strdup_split(&str[j], delims);
+		if (split[i] == NULL)
+			return (free_split(split));
+		i++;
+		while (!is_delims(str[j], delims) && str[j])
+		{
+			if (is_quote(str[j]))
+				j += skip_quotes(&str[j], str[j]);
+			j++;
+		}
+	}
+	return (split);
+}

--- a/expander/test/expansion_test.c
+++ b/expander/test/expansion_test.c
@@ -195,7 +195,6 @@ int main(int ac, char **av) {
 		char input[] = "\"echo hello\"";
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "\"echo hello\""},
-				{COMMAND_ARG_NODE, "error"},
 		};
 		test_expander(input, expected, WORD_SPLIT, environ);
 	}
@@ -205,7 +204,15 @@ int main(int ac, char **av) {
 		t_test expected[] = {
 				{COMMAND_ARG_NODE, "\"ls -l\"echo"},
 				{COMMAND_ARG_NODE, "hello"},
-				{COMMAND_ARG_NODE, "error"},
+		};
+		test_expander(input, expected, WORD_SPLIT, environ);
+	}
+	{
+		setenv("TEST", "echo hello", 1);
+		char input[] = "hoge\"ls -l\"$TEST";
+		t_test expected[] = {
+				{COMMAND_ARG_NODE, "hoge\"ls -l\"echo"},
+				{COMMAND_ARG_NODE, "hello"},
 		};
 		test_expander(input, expected, WORD_SPLIT, environ);
 	}


### PR DESCRIPTION
- Update: wordsplitting skips quotes

## Purpose
以下のような入力が与えられた時
```bash
$ export TEST="echo hello"
$ $TEST
hello

$ "echo hello"
bash: echo hello: command not found
```
`', "`で囲まれているか否かで、書く文字列を分割するか否かが決まる。

以前のPRでは、`', "`内の`<space><tab><newline>`も区切りとして複数の文字列に分解していたが、今回はそこを判別して正しく文字列を分解できるようにした。

## Effect
上記の例のように、expander以降の処理で、入力が正しいコマンドなのか、存在しないコマンドなのか等、正しく判断できるようになる。


## Memo
昨日作った`split_by_delims()`に`',"`を読み飛ばす`skip_quotes()`という関数を加えて、`split_by_delims_skip_quotes()`という関数を作った。

この2つの関数の扱いは審議。(`skip_quotes()`を追加した状態で`utils`に置くか否か等)