### PR TITLE
`pwd`コマンドの追加

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -7,5 +7,6 @@
 #include "../../libft/libft.h"
 
 int		cd(int argc, char **argv);
+int		pwd();
 
 #endif //BUILTIN_H

--- a/builtin/pwd.c
+++ b/builtin/pwd.c
@@ -1,0 +1,16 @@
+#include "builtin.h"
+
+int	pwd()
+{
+	char	*cwd;
+
+	cwd = getcwd(NULL, 0);
+	if (!cwd)
+	{
+		perror("minishell: pwd"); //todo: cannot reproduce EACCES
+		return (EXIT_FAILURE);
+	}
+	ft_putendl_fd(cwd, 1);
+	free(cwd);
+	return (EXIT_SUCCESS);
+}

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -57,6 +57,7 @@ int	ex_perror(t_executor *e, const char *s)
 bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast)
 {
 	if (!ft_strcmp(argv[0], "cd"))
+<<<<<<< HEAD
 	{
 		if (islast)
 			e->exit_status = cd(argc, argv);
@@ -76,4 +77,10 @@ bool	is_execute_condition(int condition, int exit_status)
 	if (condition == CONDITION_NL)
 		return (true);
 	return (false);
+=======
+		return (cd(argc, argv));
+	if (!ft_strcmp(argv[0], "pwd"))
+		return (pwd());
+	return (NOT_BUILTIN);
+>>>>>>> b579d9e6a539d739d22e6a8659af5a41c092d393
 }

--- a/test/cases/pwd.txt
+++ b/test/cases/pwd.txt
@@ -1,0 +1,3 @@
+pwd
+pwd a
+pwd a b


### PR DESCRIPTION
## Purpose

ノーマルチェック
- `pwd()`の実装
- `execution`が`pwd()`を実行する

## Effect

さらなるテストパス！

## Test

```
$ cd /minishell/test
$ ./greademe.sh -c
```