### PR TITLE
リダイレクト先の展開結果が不正な場合のエラー処理を追加

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -1,13 +1,16 @@
 #include "expander.h"
 
-void		search_command_arg_node(t_expander *e, t_ast_node *node);
+t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node);
 char		*expand_word(t_expander *e, char delimiter);
 char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
 char		*expand_environment_variable(char *data, size_t replace_starts, t_expander *e);
 char		*expand_wildcard(char *data, size_t pre_len, t_expander *e);
-t_ast_node	*word_splitting(t_ast_node *node, t_expander *e);
-t_ast_node	*remove_quotes(t_ast_node *node, t_expander *e);
+t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data);
+// t_ast_node	*remove_quotes(t_ast_node *node, t_expander *e);
+char		*remove_quotes(char *data, t_expander *e);
 
+// todo: expander in execute
+// t_ast_node	*expand(t_expander *e, t_env_var *env_vars, int exit_status)
 t_ast_node	*expand(t_ast_node *root, char **environ)
 {
 	t_expander	*e;
@@ -17,25 +20,37 @@ t_ast_node	*expand(t_ast_node *root, char **environ)
 		return (NULL);
 	if (!new_expander(&e, root))
 		exit(expand_perror(NULL, "malloc"));
-	search_command_arg_node(e, root);
+	if (!search_command_arg_node(e, root))
+		return (NULL);
 	free(e);
 	return (root);
 }
 
-void	search_command_arg_node(t_expander *e, t_ast_node *node)
+t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node)
 {
+	char	*original_data;
+
 	if (!node)
-		return ;
+		return (NULL);
 	search_command_arg_node(e, node->right);
 	search_command_arg_node(e, node->left);
+	if (!node)
+		return (NULL);
 	if (node->type != COMMAND_ARG_NODE && node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE && node->type != REDIRECT_APPEND_NODE)
-		return ;
+		return (node);
+	original_data = ft_strdup(node->data);
+	if (!original_data)
+		exit(expand_perror(e, "malloc"));
 	e->node = node;
 	node->data = expand_word(e, '$');
 	node->data = expand_word(e, '*');
-	node = word_splitting(node, e);
-	node = remove_quotes(node, e);
+	node = word_splitting(node, e, original_data);
+	if (!node)
+		return (NULL);
+	free(original_data);
+	node->data = remove_quotes(node->data, e);
+	return (node);
 }
 
 char	*expand_word(t_expander *e, char delimiter)
@@ -59,8 +74,6 @@ char	*expand_word(t_expander *e, char delimiter)
 			double_quote++;
 		else if (in_quotes_type(data[i], double_quote) == SINGLE_QUOTE)
 			single_quote++;
-		// double_quote += (data[i] == '\"' && !(single_quote & 1));
-		// single_quote += (data[i] == '\'' && !(double_quote & 1));
 		if (data[i] == '$' && single_quote % 2 == 0 && delimiter == '$')
 			data = expand_environment_variable(data, i, e);
 		else if (data[i] == '*' && double_quote % 2 == 0 && single_quote % 2 == 0 && delimiter == '*')
@@ -127,7 +140,7 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 	return (rtn);
 }
 
-t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
+t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data)
 {
 	char		**split;
 	size_t		i;
@@ -136,6 +149,8 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 
 	if (!node->data)
 		return (NULL);
+	if (!*node->data && *original_data)
+		return (expand_redirect_error(original_data));
 	if (!*node->data)
 		return (node);
 	split = split_by_space_skip_quotes(node->data, " \t\n");
@@ -147,7 +162,11 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 	while (split[i])
 	{
 		if (i == 0)
+		{
 			node->data = split[i];
+			if (node->type != COMMAND_ARG_NODE && ft_strcmp(node->data, original_data))
+				return (expand_redirect_error(original_data));
+		}
 		else
 		{
 			if (!new_ast_node(&result))
@@ -162,19 +181,19 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e)
 	return (root);
 }
 
-t_ast_node	*remove_quotes(t_ast_node *node, t_expander *e)
+char	*remove_quotes(char *data, t_expander *e)
 {
 	size_t	unquoted_len;
 	char	*unquoted_str;
 
-	if (!is_contain_quotes(node->data))
-		return (node);
-	unquoted_len = unquoted_strlen(node->data);
+	if (!is_contain_quotes(data))
+		return (data);
+	unquoted_len = unquoted_strlen(data);
 	unquoted_str = malloc(sizeof(char) * (unquoted_len + 1));
 	if (!unquoted_str)
 		exit(expand_perror(e, "malloc"));
-	unquoted_str = unquoted_memmove(unquoted_str, node->data);
-	free(node->data);
-	node->data = unquoted_str;
-	return (node);
+	unquoted_str = unquoted_memmove(unquoted_str, data);
+	free(data);
+	data = unquoted_str;
+	return (data);
 }

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -31,10 +31,9 @@ t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node)
 	char	*original_data;
 
 	if (!node)
-		return (NULL);
-	search_command_arg_node(e, node->right);
-	search_command_arg_node(e, node->left);
-	if (!node)
+		return (e->node);
+	if (!search_command_arg_node(e, node->right)
+		|| !search_command_arg_node(e, node->left))
 		return (NULL);
 	if (node->type != COMMAND_ARG_NODE && node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE && node->type != REDIRECT_APPEND_NODE)
@@ -146,6 +145,7 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data)
 	size_t		i;
 	t_ast_node	*root;
 	t_ast_node	*result;
+	t_ast_node	*original_right;
 
 	if (!node->data)
 		return (NULL);
@@ -159,6 +159,7 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data)
 	free(node->data);
 	i = 0;
 	root = node;
+	original_right = root->right;
 	while (split[i])
 	{
 		if (i == 0)
@@ -178,6 +179,7 @@ t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data)
 		}
 		i++;
 	}
+	node->right = original_right;
 	return (root);
 }
 

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -28,12 +28,10 @@ void	search_command_arg_node(t_expander *e, t_ast_node *node)
 		return ;
 	search_command_arg_node(e, node->right);
 	search_command_arg_node(e, node->left);
-	if (node->type != COMMAND_ARG_NODE)
+	if (node->type != COMMAND_ARG_NODE && node->type != REDIRECT_IN_NODE
+		&& node->type != REDIRECT_OUT_NODE && node->type != REDIRECT_APPEND_NODE)
 		return ;
 	e->node = node;
-	// todo: export env_var
-	// if (!ft_strcmp(node->data, "export"))
-	// 	export_env_var();
 	node->data = expand_word(e, '$');
 	node->data = expand_word(e, '*');
 	node = word_splitting(node, e);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -36,6 +36,7 @@ t_ast_node	*expand(t_ast_node *root, char **envp);
 bool		new_expander(t_expander **e, t_ast_node *root);
 bool		is_expandable_string(char *str, char delimiter);
 int			expand_perror(t_expander *e, const char *s);
+void		*expand_redirect_error(char *original_data);
 
 // expander_env.c
 size_t		var_strlen(const char *str);

--- a/expander/expander_utils.c
+++ b/expander/expander_utils.c
@@ -21,9 +21,15 @@ int	expand_perror(t_expander *e, const char *s)
 {
 	perror(s);
 	if (e)
-	{
-		delete_ast_nodes(e->root, NULL);
-	}
+		delete_ast_nodes(e->node, NULL);
 	free(e);
 	return (EXIT_FAILURE);
+}
+
+void		*expand_redirect_error(char *original_data)
+{
+	ft_putstr_fd("minishell: ", 2);
+	ft_putstr_fd(original_data, 2);
+	ft_putendl_fd(": ambiguous redirect", 2);
+	return (NULL);
 }

--- a/test/cases/expansion.txt
+++ b/test/cases/expansion.txt
@@ -12,3 +12,5 @@ echo '*'
 ls *
 echo *.'c'
 echo mini*
+echo hello > res*
+echo hello > $KONIAHI


### PR DESCRIPTION
- Add: redirect_node exoand conditions
- Update: malloc error handling
- Update: ast_node connect after wordsplitting, return NULL when inputed invalid redirect operand

## Purpose
- 以下のようなリダイレクトのパターンがきた時に、`expand`でエラーの判断とメッセージ表示のみを行い、処理結果として`NULL`を返すようにした。
```bash
$ echo hello > res*
bash: res*: ambiguous redirect

$ export TEST="res res2"
$ echo hello > $TEST
bash: $TEST: ambiguous redirect

$ echo hello > ""
bash: : No such file or directory
```


## Effect
`execute`に渡る前にエラーの検出、表示が行えるため、`&&, ||`などが入力された場合の処理がやりやすくなりそう？


## Memo
- `execute`の中に`expand`を入れる予定ではあるが、まだ色々なエラー処理や、引数の型などはガバいので、そこは合体させてから見るしかない気がします。