### PR TITLE
#69 で書いた`heredoc`が動かないケースを修正

### DIFF
--- a/execute/execute.c
+++ b/execute/execute.c
@@ -120,6 +120,6 @@ int execute_simple_command(t_executor *e, t_simple_command *sc, bool islast, int
 	}
 	else if (pid < 0)
 		exit(ex_perror(e, "minishell: fork"));
-
+	//todo: check islast
 	return (pid);
 }

--- a/utils/get_next_line.c
+++ b/utils/get_next_line.c
@@ -26,9 +26,9 @@ int	get_next_line(int fd, char **line)
 	ssize_t			read_bytes;
 	t_gnl_status	status;
 
-	if (!assign_mem((void **)line, malloc(sizeof(char) * 1)))
+	*line = ft_strdup("");
+	if (!*line)
 		return (GNL_STATUS_ERROR_MALLOC);
-	*line[0] = '\0';
 	status = GNL_STATUS_NOT_FINISHED;
 	if (buff[0])
 		status = process_buffer(buff, line);


### PR DESCRIPTION
## Purpose

チェックイン
- `heredoc`の下記ケースに対応
```
echo hello | cat << a
```

## Memo
こんな感じでbugをreproduceして見てたら、普通に親プロセスが動いてることに気づきました...汗
https://gist.github.com/tacomea/8cca6682a8ed0337c1172cd280a79c7f

pipenの理解を広げるためにこんなテストとかもしてみました。興味あったら見てみてください。
https://gist.github.com/tacomea/a6d3f9a9f37ddb4b1ada894e143bedb6