### PR TITLE
`compound list`周りの処理を修正

### DIFF
--- a/execute/execute.h
+++ b/execute/execute.h
@@ -40,6 +40,7 @@ typedef enum e_list_type {
 	T_REDIRECT_OUT,
 	T_REDIRECT_IN,
 	T_SIMPLE_COMMAND,
+	T_COMPOUND_LIST,
 	T_SUBSHELL,
 	T_PIPELINE,
 }	t_list_type;
@@ -59,16 +60,13 @@ struct s_pipeline {
 
 struct s_subshell {
 	t_compound_list		*compound_list;
-	// redirect list
-	t_redirect_out 		*r_out;
-	t_redirect_in 		*r_in;
 };
 
 struct s_compound_list {
-	int			exit_status;
-	int			condition;
-	t_pipeline 	*pipeline;
-	t_ast_node	*compound_list_next;
+	int				condition;
+	t_pipeline 		*pipeline;
+	t_ast_node		*compound_list_next;
+	t_compound_list	*next;
 };
 
 struct s_simple_command {
@@ -103,6 +101,7 @@ bool	new_argv(t_simple_command *sc);
 
 // execute_utils.c
 bool	new_executor(t_executor **e, t_ast_node *root);
+void	delete_executor(t_executor **e);
 int		ex_perror(t_executor *e, const char *s);
 void	delete_list(void *element, t_list_type type);
 bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast);

--- a/execute/execute_init.c
+++ b/execute/execute_init.c
@@ -14,8 +14,7 @@ int	execute(t_ast_node *root)
 		return (EXIT_FAILURE);
 	if (!new_executor(&e, root))
 		return (ex_perror(NULL, "malloc"));
-	command_line(e, root);
-	exit_status = e->exit_status;
+	exit_status = command_line(e, root);
 	delete_ast_nodes(e->root, NULL);
 	free(e);
 	return (exit_status);

--- a/execute/execute_init_utils.c
+++ b/execute/execute_init_utils.c
@@ -17,8 +17,6 @@ bool	new_t_subshell(t_subshell **ss)
 	if (!*ss)
 		return (false);
 	(*ss)->compound_list = NULL;
-	(*ss)->r_out = NULL;
-	(*ss)->r_in = NULL;
 	return (true);
 }
 
@@ -27,10 +25,10 @@ bool	new_t_compound_list(t_compound_list **cl)
 	*cl = malloc(sizeof(**cl));
 	if (!*cl)
 		return (false);
-	(*cl)->exit_status = -1; //idk what should be the default
-	(*cl)->condition = -1;
+	 // (*cl)->condition will not be used w/ being initialized in init_compound_list()
 	(*cl)->pipeline = NULL;
 	(*cl)->compound_list_next = NULL;
+	(*cl)->next = NULL;
 	return (true);
 }
 


### PR DESCRIPTION
## Purpose

チェックイン
- `compound list`内での`condition`に対応
- `compound list`が複数続いた際の`free()`処理

## Effect
下記のようなケースに対応
```
$ ec hello || echo fail
```

```
$ rm res rm res2
$ ls -l | (wc -l > res && echo hello > res2)
```

## Memo
- `execute_compound_list()`のループ処理結構見にくいです...すんません

- `command line && command line`のようなケースで再起で動き、`command line`では絶対に`is_execute_condition`の処理が入ってくるので、`new_t_executor()`で`condition`にデフォルト値を持たせて、一番最初の判定を通るようにしています。
逆に`compound_list`は再起で呼ばれても、一番目の呼び出しは`command_line()`の方で`is_execute_condition`の判定が入るので、`new_t_compound_list()`でデフォルト値を持たせてないです。
（自分も頭こんがらがってるので、違ってたらすみません笑笑）