### PR TITLE
builtinの`export`を追加

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -18,5 +18,6 @@ int		builtin_pwd(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_exit(int argc, char **argv, int last_exit_status, t_env_var **env_vars);
 int		builtin_echo(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars);
+int		builtin_env(int argc, char **argv, int no_use, t_env_var **env_vars);
 
 #endif //BUILTIN_H

--- a/builtin/builtin_env.c
+++ b/builtin/builtin_env.c
@@ -1,0 +1,20 @@
+#include "builtin.h"
+
+int		print_env_vars(t_env_var *env_vars)
+{
+	while (env_vars)
+	{
+		if (env_vars->value)
+			printf("%s=%s\n", env_vars->key, env_vars->value);
+		env_vars = env_vars->next;
+	}
+	return (EXIT_SUCCESS);
+}
+
+int		builtin_env(int argc, char **argv, int no_use, t_env_var **env_vars)
+{
+	(void)argc;
+	(void)argv;
+	(void)no_use;
+	return (print_env_vars(*env_vars));
+}

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -101,6 +101,11 @@ bool	execute_builtin(t_executor *e, int argc, char **argv, bool is_last)
 		execute_builtin_internal(argc, argv, e, is_last, builtin_export);
 		return (true);
 	}
+	else if (!ft_strcmp(argv[0], "env"))
+	{
+		execute_builtin_internal(argc, argv, e, is_last, builtin_env);
+		return (true);
+	}
 	return (false);
 }
 


### PR DESCRIPTION
## Purpose
builtin commandの`export`を追加。

課題PDFに、以下のような記載があったので、全ての引数・オプションを無視して、ただただ環境変数リストを表示するだけのコマンドになった。
> ◦ env with no options or arguments


## Effect
環境変数リストの確認が楽！！

