### PR TITLE
builtinの`unset`を追加

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -19,5 +19,6 @@ int		builtin_exit(int argc, char **argv, int last_exit_status, t_env_var **env_v
 int		builtin_echo(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_env(int argc, char **argv, int no_use, t_env_var **env_vars);
+int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars);
 
 #endif //BUILTIN_H

--- a/builtin/builtin_export.c
+++ b/builtin/builtin_export.c
@@ -70,7 +70,7 @@ int	print_declaration(t_env_var *env_vars)
 	return (EXIT_SUCCESS);
 }
 
-bool	is_valid_argument(char *argv)
+static bool	is_valid_argument(char *argv)
 {
 	bool	is_valid;
 

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -31,27 +31,24 @@ t_env_var	*delete_env_var(char *key, t_env_var *env_vars)
 {
 	t_env_var	*head_var;
 	t_env_var	*pre_var;
-	t_env_var	*next_var;
 
 	head_var = env_vars;
 	pre_var = NULL;
 	while (env_vars)
 	{
-		next_var = env_vars->next;
 		if (!ft_strcmp(key, env_vars->key))
 		{
 			if (pre_var)
-				pre_var->next = next_var;
+				pre_var->next = env_vars->next;
+			else
+				head_var = env_vars->next;
 			free(env_vars->key);
 			free(env_vars->value);
 			free(env_vars);
-			if (!pre_var)
-				return (next_var);
-			else
-				return (head_var);
+			return (head_var);
 		}
 		pre_var = env_vars;
-		env_vars = next_var;
+		env_vars = env_vars->next;
 	}
 	return (head_var);
 }

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -1,0 +1,85 @@
+#include "builtin.h"
+
+bool	print_argument_error(char *argv)
+{
+	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd(argv, STDERR_FILENO);
+	ft_putstr_fd("': not a valid identifier\n", STDERR_FILENO);
+	return (false);
+}
+
+static bool	is_valid_argument(char *argv)
+{
+	const size_t	len = strlen(argv);
+	size_t			i;
+
+	if (!len)
+		return (print_argument_error(argv));
+	i = 0;
+	while (i < len)
+	{
+		if (i == 0 && !ft_isalpha(argv[i]))
+			return (print_argument_error(argv));
+		else if (i != 0 && !ft_isalnum(argv[i]))
+			return (print_argument_error(argv));
+		i++;
+	}
+	return (true);
+}
+
+bool	delete_env_var(char *key, t_env_var *env_vars)
+{
+	t_env_var	*pre_var;
+
+	pre_var = NULL;
+	while (env_vars)
+	{
+		if (!ft_strcmp(key, env_vars->key))
+		{
+			if (pre_var)
+				pre_var->next = env_vars->next;
+			free(env_vars->key);
+			free(env_vars->value);
+			free(env_vars);
+			if (!pre_var)
+				return (false);
+			else
+				return (true);
+		}
+		pre_var = env_vars;
+		env_vars = env_vars->next;
+	}
+	return (true);
+}
+
+int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
+{
+	int			i;
+	int			exit_status;
+	char		*key;
+	t_env_var	*next_var;
+
+	(void)no_use;
+	exit_status = EXIT_SUCCESS;
+	if (argc == 1)
+		return (exit_status);
+	if (*env_vars)
+		next_var = (*env_vars)->next;
+	i = 1;
+	while (argv[i])
+	{
+		if (is_valid_argument(argv[i]))
+		{
+			key = ft_strdup(argv[i]);
+			if (!key)
+				return (BUILTIN_MALLOC_ERROR);
+			if (!delete_env_var(key, *env_vars))
+				*env_vars = next_var;
+			free(key);
+		}
+		else
+			exit_status = EXIT_FAILURE;
+		i++;
+	}
+	return (exit_status);
+}

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -27,29 +27,33 @@ static bool	is_valid_argument(char *argv)
 	return (true);
 }
 
-bool	delete_env_var(char *key, t_env_var *env_vars)
+t_env_var	*delete_env_var(char *key, t_env_var *env_vars)
 {
+	t_env_var	*head_var;
 	t_env_var	*pre_var;
+	t_env_var	*next_var;
 
+	head_var = env_vars;
 	pre_var = NULL;
 	while (env_vars)
 	{
+		next_var = env_vars->next;
 		if (!ft_strcmp(key, env_vars->key))
 		{
 			if (pre_var)
-				pre_var->next = env_vars->next;
+				pre_var->next = next_var;
 			free(env_vars->key);
 			free(env_vars->value);
 			free(env_vars);
 			if (!pre_var)
-				return (false);
+				return (next_var);
 			else
-				return (true);
+				return (head_var);
 		}
 		pre_var = env_vars;
-		env_vars = env_vars->next;
+		env_vars = next_var;
 	}
-	return (true);
+	return (head_var);
 }
 
 int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
@@ -57,14 +61,11 @@ int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
 	int			i;
 	int			exit_status;
 	char		*key;
-	t_env_var	*next_var;
 
 	(void)no_use;
 	exit_status = EXIT_SUCCESS;
-	if (argc == 1)
+	if (argc == 1 || !*env_vars)
 		return (exit_status);
-	if (*env_vars)
-		next_var = (*env_vars)->next;
 	i = 1;
 	while (argv[i])
 	{
@@ -73,8 +74,7 @@ int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
 			key = ft_strdup(argv[i]);
 			if (!key)
 				return (BUILTIN_MALLOC_ERROR);
-			if (!delete_env_var(key, *env_vars))
-				*env_vars = next_var;
+			*env_vars = delete_env_var(key, *env_vars);
 			free(key);
 		}
 		else

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -106,6 +106,11 @@ bool	execute_builtin(t_executor *e, int argc, char **argv, bool is_last)
 		execute_builtin_internal(argc, argv, e, is_last, builtin_env);
 		return (true);
 	}
+	else if (!ft_strcmp(argv[0], "unset"))
+	{
+		execute_builtin_internal(argc, argv, e, is_last, builtin_unset);
+		return (true);
+	}
 	return (false);
 }
 

--- a/libft/ft_isalnum.c
+++ b/libft/ft_isalnum.c
@@ -1,0 +1,6 @@
+#include "libft.h"
+
+int	ft_isalnum(char c)
+{
+	return (ft_isdigit(c) || ft_isalpha(c));
+}

--- a/libft/ft_isalnum.c
+++ b/libft/ft_isalnum.c
@@ -1,6 +1,6 @@
 #include "libft.h"
 
-int	ft_isalnum(char c)
+int	ft_isalnum(int c)
 {
 	return (ft_isdigit(c) || ft_isalpha(c));
 }

--- a/libft/ft_isalpha.c
+++ b/libft/ft_isalpha.c
@@ -1,0 +1,6 @@
+#include "libft.h"
+
+int	ft_isalpha(int c)
+{
+	return (('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z'));
+}


### PR DESCRIPTION
- Add: ft_isalpha, ft_isalnum
- Fix: argument type
- Add: builtin_unset

## Purpose
- `unset`を追加。
- `delete_env_var()`は、引数の`key`に該当する環境変数がリストに存在する場合、`free()`する関数であるが、それがリストの先頭であった場合、ちょっと扱いがめんどくさくなる。
- 先頭を`free()`してそのまま処理を続けてしまうと、後に`env`, `export`を呼び出した時に`free()`した領域を読んでしまうため、Abortする。
- そのため、`*env_vars`が`NULL`（リストが空）でない場合、リストの２番目のアドレスを`next_var`に保存しておいて、`delete_env_var()`において`free()`した環境変数が先頭の場合（`pre_var`が`NULL`）、`*env_var = next_var;`で元々の2番目のアドレスを先頭に繋ぐ必要がある。


## Effect
- このコマンドできてたら、`expand`, `execute`と合わせて色々テストできそう！


## Memo
- `export`, `unset`の両方で`is_valid_argument()`という関数を用いているが、`unset`の方を`util`化した方が使い勝手が良さそう。
- `export`のエラー処理が地味にミスってまして、
```bash
# 1文字の場合はこれでいいが、
$ unset =
bash: unset: `=': not a valid identifier
'

# 文字列の構成が不正な場合、文字列全体をエラーメッセージに含める必要がある。
$ unset TEST=test
bash: unset: `TSET=test': not a valid identifier 
```
- 引数のエラーパターンどこまで対応するか悩み中です笑笑