### PR TITLE
`export`コマンドなどに使用していた`is_valid_argument`を`utils`に移行

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -7,6 +7,9 @@
 
 #define BUILTIN_MALLOC_ERROR -1
 
+#define EXPORT_ARG_ERROR 0
+#define UNSET_ARG_ERROR 1
+
 #include "../libft/libft.h"
 #include "../utils/utils.h"
 #include "../execute/execute.h"

--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -24,4 +24,6 @@ int		builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_env(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars);
 
+bool	is_valid_argument(char *argv, size_t len, int error_type);
+
 #endif //BUILTIN_H

--- a/builtin/builtin_export.c
+++ b/builtin/builtin_export.c
@@ -150,7 +150,7 @@ int	builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars)
 	i = 1;
 	while (i < argc)
 	{
-		if (is_valid_argument(argv[i]))
+		if (is_valid_argument(argv[i], key_strlen(argv[i])))
 		{
 			if (set_key_value(&key, &value, argv[i]) == BUILTIN_MALLOC_ERROR)
 				return (BUILTIN_MALLOC_ERROR);

--- a/builtin/builtin_export.c
+++ b/builtin/builtin_export.c
@@ -150,7 +150,7 @@ int	builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars)
 	i = 1;
 	while (i < argc)
 	{
-		if (is_valid_argument(argv[i], key_strlen(argv[i])))
+		if (is_valid_argument(argv[i], key_strlen(argv[i]), EXPORT_ARG_ERROR))
 		{
 			if (set_key_value(&key, &value, argv[i]) == BUILTIN_MALLOC_ERROR)
 				return (BUILTIN_MALLOC_ERROR);

--- a/builtin/builtin_export.c
+++ b/builtin/builtin_export.c
@@ -70,21 +70,6 @@ int	print_declaration(t_env_var *env_vars)
 	return (EXIT_SUCCESS);
 }
 
-static bool	is_valid_argument(char *argv)
-{
-	bool	is_valid;
-
-	is_valid = true;
-	if (argv[0] == '=' || argv[0] == '\0')
-	{
-		ft_putstr_fd("minishell: export: `", STDERR_FILENO);
-		ft_putchar_fd(argv[0], STDERR_FILENO);
-		ft_putstr_fd("': not a valid identifier\n", STDERR_FILENO);
-		is_valid = false;
-	}
-	return (is_valid);
-}
-
 t_env_var	*search_env_key(char *key, t_env_var *env_vars, bool *exist)
 {
 	while (env_vars)

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -1,32 +1,5 @@
 #include "builtin.h"
 
-bool	print_argument_error(char *argv)
-{
-	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
-	ft_putstr_fd(argv, STDERR_FILENO);
-	ft_putstr_fd("': not a valid identifier\n", STDERR_FILENO);
-	return (false);
-}
-
-static bool	is_valid_argument(char *argv)
-{
-	const size_t	len = strlen(argv);
-	size_t			i;
-
-	if (!len)
-		return (print_argument_error(argv));
-	i = 0;
-	while (i < len)
-	{
-		if (i == 0 && !ft_isalpha(argv[i]))
-			return (print_argument_error(argv));
-		else if (i != 0 && !ft_isalnum(argv[i]))
-			return (print_argument_error(argv));
-		i++;
-	}
-	return (true);
-}
-
 t_env_var	*delete_env_var(char *key, t_env_var *env_vars)
 {
 	t_env_var	*head_var;

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -39,7 +39,7 @@ int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
 	i = 1;
 	while (argv[i])
 	{
-		if (is_valid_argument(argv[i], ft_strlen(argv[i])))
+		if (is_valid_argument(argv[i], ft_strlen(argv[i]), UNSET_ARG_ERROR))
 		{
 			key = ft_strdup(argv[i]);
 			if (!key)

--- a/builtin/builtin_unset.c
+++ b/builtin/builtin_unset.c
@@ -39,7 +39,7 @@ int		builtin_unset(int argc, char **argv, int no_use, t_env_var **env_vars)
 	i = 1;
 	while (argv[i])
 	{
-		if (is_valid_argument(argv[i]))
+		if (is_valid_argument(argv[i], ft_strlen(argv[i])))
 		{
 			key = ft_strdup(argv[i]);
 			if (!key)

--- a/builtin/is_valid_argument.c
+++ b/builtin/is_valid_argument.c
@@ -1,4 +1,4 @@
-#include "utils.h"
+#include "builtin.h"
 
 static bool	print_argument_error(char *argv, int error_type)
 {

--- a/utils/is_valid_argument.c
+++ b/utils/is_valid_argument.c
@@ -18,9 +18,9 @@ bool	is_valid_argument(char *argv)
 	i = 0;
 	while (i < len)
 	{
-		if (i == 0 && !ft_isalpha(argv[i]))
+		if (i == 0 && !ft_isalpha(argv[i]) && argv[i] != '_')
 			return (print_argument_error(argv));
-		else if (i != 0 && !ft_isalnum(argv[i]))
+		else if (i != 0 && !ft_isalnum(argv[i]) && argv[i] != '_')
 			return (print_argument_error(argv));
 		i++;
 	}

--- a/utils/is_valid_argument.c
+++ b/utils/is_valid_argument.c
@@ -1,0 +1,28 @@
+#include "utils.h"
+
+static bool	print_argument_error(char *argv)
+{
+	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd(argv, STDERR_FILENO);
+	ft_putstr_fd("': not a valid identifier\n", STDERR_FILENO);
+	return (false);
+}
+
+bool	is_valid_argument(char *argv)
+{
+	const size_t	len = ft_strlen(argv);
+	size_t			i;
+
+	if (!len)
+		return (print_argument_error(argv));
+	i = 0;
+	while (i < len)
+	{
+		if (i == 0 && !ft_isalpha(argv[i]))
+			return (print_argument_error(argv));
+		else if (i != 0 && !ft_isalnum(argv[i]))
+			return (print_argument_error(argv));
+		i++;
+	}
+	return (true);
+}

--- a/utils/is_valid_argument.c
+++ b/utils/is_valid_argument.c
@@ -8,9 +8,8 @@ static bool	print_argument_error(char *argv)
 	return (false);
 }
 
-bool	is_valid_argument(char *argv)
+bool	is_valid_argument(char *argv, size_t len)
 {
-	const size_t	len = ft_strlen(argv);
 	size_t			i;
 
 	if (!len)

--- a/utils/is_valid_argument.c
+++ b/utils/is_valid_argument.c
@@ -1,26 +1,30 @@
 #include "utils.h"
 
-static bool	print_argument_error(char *argv)
+static bool	print_argument_error(char *argv, int error_type)
 {
-	ft_putstr_fd("minishell: export: `", STDERR_FILENO);
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	if (error_type == EXPORT_ARG_ERROR)
+		ft_putstr_fd("export: `", STDERR_FILENO);
+	else if (error_type == UNSET_ARG_ERROR)
+		ft_putstr_fd("unset: `", STDERR_FILENO);
 	ft_putstr_fd(argv, STDERR_FILENO);
 	ft_putstr_fd("': not a valid identifier\n", STDERR_FILENO);
 	return (false);
 }
 
-bool	is_valid_argument(char *argv, size_t len)
+bool	is_valid_argument(char *argv, size_t len, int error_type)
 {
 	size_t			i;
 
 	if (!len)
-		return (print_argument_error(argv));
+		return (print_argument_error(argv, error_type));
 	i = 0;
 	while (i < len)
 	{
 		if (i == 0 && !ft_isalpha(argv[i]) && argv[i] != '_')
-			return (print_argument_error(argv));
+			return (print_argument_error(argv, error_type));
 		else if (i != 0 && !ft_isalnum(argv[i]) && argv[i] != '_')
-			return (print_argument_error(argv));
+			return (print_argument_error(argv, error_type));
 		i++;
 	}
 	return (true);

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -2,6 +2,7 @@
 # define UTILS_H
 
 # include <stdlib.h>
+# include <unistd.h>
 
 # include "../libft/libft.h"
 
@@ -11,5 +12,6 @@ char	*ft_strndup(const char *str, size_t size);
 void	free_2d_array(void ***array);
 char	**split_by_delims(char const *str, const char *delims);
 bool	atoi_strict(const char *str, int *num);
+bool	is_valid_argument(char *argv);
 
 # endif //UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -13,6 +13,5 @@ char	*ft_strndup(const char *str, size_t size);
 void	free_2d_array(void ***array);
 char	**split_by_delims(char const *str, const char *delims);
 bool	atoi_strict(const char *str, int *num);
-bool	is_valid_argument(char *argv, size_t len, int error_type);
 
 # endif //UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -5,6 +5,7 @@
 # include <unistd.h>
 
 # include "../libft/libft.h"
+# include "../builtin/builtin.h"
 
 bool	assign_mem(void **dst, void *src);
 char	*strappend(char *dst, const char *src, size_t l);
@@ -12,6 +13,6 @@ char	*ft_strndup(const char *str, size_t size);
 void	free_2d_array(void ***array);
 char	**split_by_delims(char const *str, const char *delims);
 bool	atoi_strict(const char *str, int *num);
-bool	is_valid_argument(char *argv, size_t len);
+bool	is_valid_argument(char *argv, size_t len, int error_type);
 
 # endif //UTILS_H

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -12,6 +12,6 @@ char	*ft_strndup(const char *str, size_t size);
 void	free_2d_array(void ***array);
 char	**split_by_delims(char const *str, const char *delims);
 bool	atoi_strict(const char *str, int *num);
-bool	is_valid_argument(char *argv);
+bool	is_valid_argument(char *argv, size_t len);
 
 # endif //UTILS_H


### PR DESCRIPTION
	- Update: split is_valid_argument() to utils
- Update: allow '_'
- Update: add argument 'len' to check export key or unset argument

## Purpose
- `is_valid_argument()`は`export`や`unset`で共通で使えそうだったので、`utils`に移行した。
- そういえば、環境変数の`key`は`_`が許されるので、そこも許可するようにした。
- また、若干エラー処理に変更を加えた。

	- `export`

	```bash
	# OK
	# valueの方の英数字以外の文字は許可する
	$ export TEST_1="~!@%*^" 


	# KO
	# keyの始まりが英字or'_'でない
	$ export 1TEST
	minishell: export: `1_TEST': not a valid identifier'

	# keyに英数字or'_'以外の文字が含まれている
	$ export TEST^*HOGE=test
	export: `TEST^*HOGE=test': not a valid identifier
	```

	- `unset`
	```bash
	# OK
	$ unset TEST HOGE


	# KO
	# unsetのほうは、keyしか必要でないため、英数字or'_'以外の文字が含まれているだけでエラーとする。
	$ unset TEST=
	minishell: export: `TEST=': not a valid identifier'

	# bashにおいて'!#@'などは意味を持つが、この課題では解釈する必要がないため、以下のように英数字or'_'以外の文字はエラーとした。
	# bash
	$ unset TEST=!@#&*%^
	bash: !@#: event not found
	# minishell
	$ unset TEST=!@#&*%^
	minishell: export: `TEST=!@#': not a valid identifier
	```


## Effect
- `export`も`unset`同様のエラー処理を行えるようになった。
- 基本的に`export`は`key`のみ、`unset`は引数全体をチェックするようにした。

## Memo
- bashにおけるここら辺のコマンドの引数エラーチェックが、どのくらいパターンあるかわからないですが、基本的に特殊文字は解釈しないという方向でエラー処理を行なってます。
- 引数に来る文字パターン多スンギ〜〜〜