### PR TITLE
`', "`の中にいるかどうかを`status`とマクロで管理

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -53,12 +53,34 @@ t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node)
 	return (node);
 }
 
+int	quotation_status(char c, int status)
+{
+	if (c == '\"')
+	{
+		if (status == IN_DOUBLE_QUOTE)
+			status = OUTSIDE;
+		else if (status == IN_SINGLE_QUOTE)
+			status = IN_SINGLE_QUOTE;
+		else
+			status = IN_DOUBLE_QUOTE;
+	}
+	else if (c == '\'')
+	{
+		if (status == IN_DOUBLE_QUOTE)
+			status = IN_DOUBLE_QUOTE;
+		else if (status == IN_SINGLE_QUOTE)
+			status = OUTSIDE;
+		else
+			status = IN_SINGLE_QUOTE;
+	}
+	return (status);
+}
+
 char	*expand_word(t_expander *e, char delimiter)
 {
 	char	*data;
+	int		status;
 	size_t	i;
-	size_t	double_quote;
-	size_t	single_quote;
 
 	data = e->node->data;
 	if (!data)
@@ -66,17 +88,13 @@ char	*expand_word(t_expander *e, char delimiter)
 	if (!is_expandable_string(data, delimiter))
 		return (data);
 	i = 0;
-	double_quote = 0;
-	single_quote = 0;
+	status = OUTSIDE;
 	while (data[i])
 	{
-		if (in_quotes_type(data[i], single_quote) == DOUBLE_QUOTE)
-			double_quote++;
-		else if (in_quotes_type(data[i], double_quote) == SINGLE_QUOTE)
-			single_quote++;
-		if (data[i] == '$' && single_quote % 2 == 0 && delimiter == '$')
+		status = quotation_status(data[i], status);
+		if (data[i] == '$' && delimiter == '$' && status != IN_SINGLE_QUOTE)
 			data = expand_environment_variable(data, i, e);
-		else if (data[i] == '*' && double_quote % 2 == 0 && single_quote % 2 == 0 && delimiter == '*')
+		else if (data[i] == '*' && delimiter == '*' && status == OUTSIDE)
 			data = expand_wildcard(data, i, e);
 		if (!data)
 			return (NULL);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -21,6 +21,10 @@
 # define SINGLE_QUOTE 1
 # define NOT_QUOTE 2
 
+# define OUTSIDE 0
+# define IN_DOUBLE_QUOTE 1
+# define IN_SINGLE_QUOTE 2
+
 typedef struct s_expander t_expander;
 
 extern char	**environ;

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -5,7 +5,6 @@
 # include <unistd.h>
 
 # include "../libft/libft.h"
-# include "../builtin/builtin.h"
 
 bool	assign_mem(void **dst, void *src);
 char	*strappend(char *dst, const char *src, size_t l);


### PR DESCRIPTION
- Update: quotation status
- Remove: inlucde 'builtin.h' in utils.h

## Purpose
- `expand`を実行するにあたり、今見ている文字が`', "`の中にいるかどうかが大きな問題となる。
- 以前は、くっっっっそわかりづらくその状態を書いて条件分岐していたが、今回は今見ている文字の状態を表す変数`status`と`OUTSIDE`, `IN_DOUBLE_QUOTE`のようなマクロを定義して、条件分岐するようにした。
- 後、`utils.h`の中で`#include "builtin.h"`としていたせいで、コンパイルエラーが発生していたので、そこも修正。

## Effect
- 前より、今見てる文字がどの状態で、どの状態の時に条件分岐するのかわかりやすくなった！
