### PR TITLE
builtinの`exit`で引数がレンジを超えた時のエラーステータスの変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OBJS    	= $(addprefix $(OBJDIR)/, $(notdir $(SRCS:.c=.o)))
 LIBFT_PATH	= libft
 
 CC      	= gcc
-CFLAG   	= -Wall -Wextra -Werror -fsanitize=address
+CFLAGS   	= -Wall -Wextra -Werror -fsanitize=address
 
 LIB			= -L$(LIBFT_PATH) -lft
 INCLUDE		=
@@ -36,13 +36,13 @@ all: $(NAME) run
 
 $(NAME): $(OBJS)
 	@make -C $(LIBFT_PATH)
-	$(CC) $(CFLAG) $^ -o $@ $(INCLUDE) $(LIB)
+	$(CC) $(CFLAGS) $^ -o $@ $(INCLUDE) $(LIB)
 
 bonus: $(NAME)
 
 $(OBJDIR)/%.o: %.c
 	@if [ ! -d $(dir $@) ];then mkdir $(dir $@); fi
-	$(CC) $(CFLAG) -o $@ -c $<
+	$(CC) $(CFLAGS) -o $@ -c $<
 
 clean:
 	@make clean -C $(LIBFT_PATH)

--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -16,6 +16,8 @@
 #include "../expander/expander.h"
 #include "../env/env.h"
 
+# define EXIT_STATUS_OUT_OF_RANGE 255
+
 int		builtin_cd(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_pwd(int argc, char **argv, int no_use, t_env_var **env_vars);
 int		builtin_exit(int argc, char **argv, int last_exit_status, t_env_var **env_vars);

--- a/builtin/builtin_exit.c
+++ b/builtin/builtin_exit.c
@@ -15,7 +15,7 @@ int builtin_exit(int argc, char **argv, int last_exit_status, t_env_var **env_va
 			ft_putendl_fd("minishell: exit: ", STDERR_FILENO);
 			ft_putendl_fd(argv[1], STDERR_FILENO);
 			ft_putendl_fd(": numeric argument required", STDERR_FILENO);
-			return (EXIT_FAILURE);
+			return (EXIT_STATUS_OUT_OF_RANGE);
 		}
 		exit((unsigned char)num); //todo: free?
 	}


### PR DESCRIPTION
## Purpose
以下のような挙動に合わせた！
```
$ bash -c "exit a"
bash: line 0: exit: a: numeric argument required
$ echo $?
255
$ echo "2 ^ 63" | bc
9223372036854775808
$ bash -c "exit 9223372036854775808"
bash: line 0: exit: 9223372036854775808: numeric argument required
$ echo $?
255
$ bash -c "exit 9223372036854775807"
$ echo $?                           
255
```

## Memo
多分、全部のMakefileが`CFLAG`になってるんですが、デフォルトの変数名が`CFLAGS`なのでそっちに統一した方がいいかもです！