### PR TITLE
パイプで処理内容をもらった時にプロンプトを表示しないようにする

### DIFF
--- a/minishell.c
+++ b/minishell.c
@@ -11,7 +11,7 @@
 #include "lexer/lexer.h"
 #include "expander/expander.h"
 #include "execute/execute.h"
-
+#include "utils/get_next_line.h"
 
 //	rl_on_new_line();
 //	rl_replace_line("", 0); // <- 現状、何故かこの関数だけがコンパイルエラーとなり動かない
@@ -38,12 +38,19 @@ int minishell(char *line)
 {
 	t_env_var	*env_vars;
 	int 		exit_status;
+	int on = 1;
 
 	env_vars = init_env_lst();
 
 	// todo: null check
 	if (register_env_var(ft_strdup("?"), ft_strdup("0"), &env_vars) == MALLOC_ERROR)
 		exit(delete_env_lst(env_vars, NULL, NULL));
+	if (line)
+		exit(execute(parse(lex(line)), &env_vars));
+	ioctl(STDIN_FILENO, FIONBIO, &on);
+	get_next_line(STDIN_FILENO, &line);
+	if (line[0])
+		exit(execute(parse(lex(line)), &env_vars));
 	exit_status = EXIT_SUCCESS;
 	set_signal_handler();
 	while (1)

--- a/minishell.c
+++ b/minishell.c
@@ -38,7 +38,6 @@ int minishell(char *line)
 {
 	t_env_var	*env_vars;
 	int 		exit_status;
-	int on = 1;
 
 	env_vars = init_env_lst();
 
@@ -46,10 +45,6 @@ int minishell(char *line)
 	if (register_env_var(ft_strdup("?"), ft_strdup("0"), &env_vars) == MALLOC_ERROR)
 		exit(delete_env_lst(env_vars, NULL, NULL));
 	if (line)
-		exit(execute(parse(lex(line)), &env_vars));
-	ioctl(STDIN_FILENO, FIONBIO, &on);
-	get_next_line(STDIN_FILENO, &line);
-	if (line[0])
 		exit(execute(parse(lex(line)), &env_vars));
 	exit_status = EXIT_SUCCESS;
 	set_signal_handler();
@@ -77,7 +72,21 @@ int minishell(char *line)
 
 int	main(int argc, char **argv)
 {
+	int				on;
+	char			*line;
+
 	if (argc == 3 && !ft_strcmp(argv[1], "-c"))
-		return (minishell(argv[2]));
-	return (minishell(NULL));
+		return (minishell(ft_strdup(argv[2])));
+	else
+	{
+		on = 1;
+		ioctl(STDIN_FILENO, FIONBIO, &on);
+		// todo: gnl status
+		// todo: what if there are two lines
+		get_next_line(STDIN_FILENO, &line);
+		if (line[0])
+			return (minishell(line));
+		free(line);
+		return (minishell(NULL));
+	}
 }

--- a/utils/get_next_line.c
+++ b/utils/get_next_line.c
@@ -17,7 +17,7 @@ static t_gnl_status	process_buffer(char buff[], char **line)
 	*line = strappend(*line, buff, ft_strlen(buff));
 	if (!*line)
 		return (GNL_STATUS_ERROR_MALLOC);
-	return (GNL_STATUS_NOT_FINISHED);
+	return (GNL_NOT_RETURNING);
 }
 
 int	get_next_line(int fd, char **line)
@@ -29,10 +29,10 @@ int	get_next_line(int fd, char **line)
 	*line = ft_strdup("");
 	if (!*line)
 		return (GNL_STATUS_ERROR_MALLOC);
-	status = GNL_STATUS_NOT_FINISHED;
+	status = GNL_NOT_RETURNING;
 	if (buff[0])
 		status = process_buffer(buff, line);
-	if (status != GNL_STATUS_NOT_FINISHED)
+	if (status != GNL_NOT_RETURNING)
 		return (status);
 	while (1)
 	{
@@ -43,7 +43,7 @@ int	get_next_line(int fd, char **line)
 		if (read_bytes == 0)
 			return (GNL_STATUS_DONE);
 		status = process_buffer(buff, line);
-		if (status != GNL_STATUS_NOT_FINISHED)
+		if (status != GNL_NOT_RETURNING)
 			return (status);
 	}
 }

--- a/utils/get_next_line.h
+++ b/utils/get_next_line.h
@@ -18,7 +18,7 @@ typedef enum e_gnl_status {
 	GNL_STATUS_ERROR_MALLOC = -1,
 	GNL_STATUS_DONE = 0,
 	GNL_STATUS_SUCCESS = 1,
-	GNL_STATUS_NOT_FINISHED = 2,
+	GNL_NOT_RETURNING = 2,
 }	t_gnl_status;
 
 int		get_next_line(int fd, char **line);


### PR DESCRIPTION
## Purpose
以下のようなケースに対応！
```
echo "echo hello" | ./minishell
```
方法としては、`readline()`に入る前にnon-blocking（入力がない場合は待たない）の`read()`を一発かましています！

## Effect
`test`ディレクトリからの`./grademe.sh`が動くようになった！！

## Memo
- `isatty()`でも同様の処理ができるようなので後で見てみる...！