### PR TITLE
`execvp`の代わりに`execve`の使用

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+:
+cat
+echo
 res*
 multi*
 minishell

--- a/execute/execute.c
+++ b/execute/execute.c
@@ -121,7 +121,17 @@ int execute_simple_command(t_executor *e, t_simple_command *sc, bool is_last, bo
 			close(pipefd[READ]);
 		if (execute_builtin(e, sc->argc, sc->argv, is_last))
 			exit(EXIT_SUCCESS);
-		if (execvp(sc->argv[0], sc->argv) == -1)
+		if (!ft_strchr(sc->argv[0], '/'))
+		{
+			if (!get_cmd_path(e, &sc->argv[0]))
+			{
+				ft_putstr_fd("minishell: ", STDERR_FILENO);
+				ft_putstr_fd(sc->argv[0], STDERR_FILENO);
+				ft_putstr_fd(": command not found", STDERR_FILENO);
+			}
+		}
+//		if (execvp(sc->argv[0], sc->argv) == -1)
+		if (execve(sc->argv[0], sc->argv, environ) == -1)
 		{
 			ft_putstr_fd("minishell: ", 2);
 			ft_putstr_fd(sc->argv[0], 2);

--- a/execute/execute.c
+++ b/execute/execute.c
@@ -130,7 +130,6 @@ int execute_simple_command(t_executor *e, t_simple_command *sc, bool is_last, bo
 				ft_putstr_fd(": command not found", STDERR_FILENO);
 			}
 		}
-//		if (execvp(sc->argv[0], sc->argv) == -1)
 		if (execve(sc->argv[0], sc->argv, environ) == -1)
 		{
 			ft_putstr_fd("minishell: ", 2);

--- a/execute/execute.h
+++ b/execute/execute.h
@@ -120,4 +120,8 @@ bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_t
 // execute_command.c
 int		execute_pipeline(t_executor *e, t_pipeline *c);
 
+// get_cmd_path.c
+char **split_path_from_env(const char *path_from_env);
+bool	get_cmd_path(t_executor *e, char **command);
+
 #endif //MINISHELL_EXECUTE_H

--- a/execute/get_cmd_path.c
+++ b/execute/get_cmd_path.c
@@ -29,6 +29,7 @@ static char **create_paths(const char *path_from_env, t_sep_list *sep_list, size
 	char	**paths;
 	size_t	start;
 	int		i;
+	size_t	len;
 
 	paths = malloc(sizeof(*paths) * (list_len + 1));
 	if (!paths)
@@ -38,7 +39,11 @@ static char **create_paths(const char *path_from_env, t_sep_list *sep_list, size
 	i = 0;
 	while (sep_list)
 	{
-		paths[i++] = ft_substr(path_from_env, start + 1, sep_list->sep_index - start - 1);
+		len = sep_list->sep_index - start - 1;
+		if (len == 0)
+			paths[i++] = getcwd(NULL, 0);//todo: check when can the returned value be NULL
+		else
+			paths[i++] = ft_substr(path_from_env, start + 1, len);
 		start = sep_list->sep_index;
 		sep_list = sep_list->next;
 	}
@@ -115,7 +120,8 @@ bool get_cmd_path(t_executor *e, char **command)
 			break ;
 		free(path);
 	}
-	free(command);
+	free(*command);
+	*command = path; // todo: argv[0] vs path
 	free_2d_array((void ***) &paths);
-	return (path);
+	return (true);
 }

--- a/execute/get_cmd_path.c
+++ b/execute/get_cmd_path.c
@@ -1,0 +1,121 @@
+#include "get_cmd_path.h"
+
+static void	destroy_sep_list(t_sep_list *head)
+{
+	t_sep_list	*next;
+
+	while (head)
+	{
+		next = head->next;
+		free(head);
+		head = next;
+	}
+}
+
+static t_sep_list *new_sep_list(int sep_index)
+{
+	t_sep_list	*new;
+
+	new = malloc(sizeof(*new));
+	if (!new)
+		return (NULL);
+	new->next = NULL;
+	new->sep_index = sep_index;
+	return (new);
+}
+
+static char **create_paths(const char *path_from_env, t_sep_list *sep_list, size_t list_len)
+{
+	char	**paths;
+	size_t	start;
+	int		i;
+
+	paths = malloc(sizeof(*paths) * (list_len + 1));
+	if (!paths)
+		return (NULL);
+	start = sep_list->sep_index;
+	sep_list = sep_list->next;
+	i = 0;
+	while (sep_list)
+	{
+		paths[i++] = ft_substr(path_from_env, start + 1, sep_list->sep_index - start - 1);
+		start = sep_list->sep_index;
+		sep_list = sep_list->next;
+	}
+	paths[i] = NULL;
+	return (paths);
+}
+
+static t_sep_list *create_sep_list(const char *path_from_env, int *list_len)
+{
+	t_sep_list	*head;
+	t_sep_list	*tail;
+	int			i;
+
+	head = new_sep_list(-1);
+	if (!head)
+		return (NULL);
+	tail = head;
+	i = -1;
+	*list_len = 1;
+	while (path_from_env[++i])
+	{
+		if (path_from_env[i] == ':')
+		{
+			tail->next = new_sep_list(i);
+			if (!tail->next)
+			{
+				destroy_sep_list(head);
+				return (NULL);
+			}
+			tail = tail->next;
+			*list_len += 1;
+		}
+	}
+	tail->next = new_sep_list(i);
+	return (head);
+}
+
+char **split_path_from_env(const char *path_from_env)
+{
+	char		**paths;
+	t_sep_list	*sep_list;
+	int			list_len;
+
+	sep_list = create_sep_list(path_from_env, &list_len);
+	if (!sep_list)
+		return (NULL);
+	paths = create_paths(path_from_env, sep_list, list_len);
+	destroy_sep_list(sep_list);
+	return (paths);
+}
+
+bool get_cmd_path(t_executor *e, char **command)
+{
+	char 	*path_from_env;
+	char	**paths;
+	char	*path;
+	int		i;
+
+	path_from_env = get_env_value("PATH", *e->env_vars);
+	if (!path_from_env)
+		return (true);
+	paths = split_path_from_env(path_from_env);
+	if (!paths)
+		exit(EXIT_FAILURE); //todo: free process
+	if (!paths[0])
+		return (true);
+	i = -1;
+	while (1)
+	{
+		if (!paths[++i])
+			return (false);
+		path = ft_strjoin(paths[i], ft_strjoin("/", *command));
+		if (access(path, F_OK) == 0)
+			break ;
+		free(path);
+	}
+	free(command);
+	free_2d_array((void ***) &paths);
+	return (path);
+}

--- a/execute/get_cmd_path.h
+++ b/execute/get_cmd_path.h
@@ -1,0 +1,15 @@
+#ifndef GET_CMD_PATH_H
+#define GET_CMD_PATH_H
+
+#include <stdbool.h>
+
+#include "execute.h"
+
+typedef struct s_sep_list	t_sep_list;
+
+struct s_sep_list {
+	int			sep_index;
+	t_sep_list	*next;
+};
+
+#endif //GET_CMD_PATH_H

--- a/execute/test/Makefile
+++ b/execute/test/Makefile
@@ -1,12 +1,19 @@
 NAME = a.out
 
+CURRENT_PATH	= .
 EXECUTE_PATH	= ..
+EXPANDER_PATH	= ../../expander
 PARSER_PATH		= ../../parser
 LEXER_PATH		= ../../lexer
 AST_PATH		= ../../ast
 UTILS_PATH		= ../../utils
-SRC_PATHS		= . $(EXECUTE_PATH) $(PARSER_PATH) $(LEXER_PATH) $(AST_PATH) $(UTILS_PATH)
+BUILTIN_PATH	= ../../builtin
+ENV_PATH		= ../../env
+
+SRC_PATHS		= $(CURRENT_PATH) $(EXPANDER_PATH) $(BUILTIN_PATH) $(EXECUTE_PATH) $(PARSER_PATH) $(LEXER_PATH) $(AST_PATH) $(UTILS_PATH) $(ENV_PATH)
 SRCS			= $(foreach path, $(SRC_PATHS), $(wildcard $(path)/*.c))
+
+VPATH		= $(CURRENT_PATH):$(BUILTIN_PATH):$(EXECUTE_PATH):$(PARSER_PATH):$(LEXER_PATH):$(AST_PATH):$(UTILS_PATH):$(ENV_PATH):$(EXPANDER_PATH)
 
 OBJDIR  = ./obj
 OBJS    = $(addprefix $(OBJDIR)/, $(notdir $(SRCS:%.c=%.o)))
@@ -25,26 +32,6 @@ $(NAME): $(OBJS)
 	$(CC) $(CFLAG) $(INCLUDE) $^ -o $@ -L$(LIBFT_PATH) -lft
 
 $(OBJDIR)/%.o: %.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAG) -o $@ -c $<
-
-$(OBJDIR)/%.o: $(EXECUTE_PATH)/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAG) -o $@ -c $<
-
-$(OBJDIR)/%.o: $(PARSER_PATH)/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAG) -o $@ -c $<
-
-$(OBJDIR)/%.o: $(LEXER_PATH)/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAG) -o $@ -c $<
-
-$(OBJDIR)/%.o: $(AST_PATH)/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAG) -o $@ -c $<
-
-$(OBJDIR)/%.o: $(UTILS_PATH)/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAG) -o $@ -c $<
 

--- a/execute/test/Makefile
+++ b/execute/test/Makefile
@@ -19,7 +19,7 @@ OBJDIR  = ./obj
 OBJS    = $(addprefix $(OBJDIR)/, $(notdir $(SRCS:%.c=%.o)))
 
 CC		= gcc
-CFLAG	= -Wall -Wextra -Werror -fsanitize=address -DTEST
+CFLAG	= -Wall -Wextra -Werror #-fsanitize=address
 
 LIBFT_PATH = ../../libft
 #INCLUDE		= -I../../lexer -I../../token -I../../ast -I../../parser

--- a/execute/test/execute_test.c
+++ b/execute/test/execute_test.c
@@ -1,32 +1,40 @@
 #include "../execute.h"
+#include "../../env/env.h"
 #include "../../lexer/lexer.h"
 #include "../../parser/parser.h"
 
-#define GENERAL_CASE -1
-#define ERROR_CASE -2
-
 #define BLUE    "\033[34m"      /* Blue */
 
-typedef struct s_test {
-	t_node_type expected_type;
-	int expected_level;
-	char expected_literal[52];
-} test;
+int main()
+{
+	t_env_var	*env_vars;
+//	t_executor *e;
 
-void test_execution(char input[], test *expected, int test_type);
-
-int main(int argc, char **argv) {
-	if (argc != 2) {
-		printf("argument num wrong");
-		return(1);
+	env_vars = init_env_lst();
+	if (register_env_var(ft_strdup("?"), ft_strdup("0"), &env_vars) == MALLOC_ERROR)
+		exit(delete_env_lst(env_vars, NULL, NULL));
+//	if (!new_executor(&e, NULL, &env_vars))
+//		exit(EXIT_FAILURE);
+	char *path_from_env = get_env_value("PATH", env_vars);
+	char **paths = split_path_from_env(path_from_env);
+	for (int i = 0; paths[i]; i++) {
+		printf("paths[%d]: %s \n", i, paths[i]);
 	}
-	t_token *token = lex(argv[1]);
-	t_ast_node *node = parse(token);
-	if (!node)
-	{
-		fprintf(stderr, RED "parse() returned NULL!\n" RESET);
-		return (1);
-	}
-	execute(node);
+//	get_cmd_path(e, "cat")
 }
+
+//int main(int argc, char **argv) {
+//	if (argc != 2) {
+//		printf("argument num wrong");
+//		return(1);
+//	}
+//	t_token *token = lex(argv[1]);
+//	t_ast_node *node = parse(token);
+//	if (!node)
+//	{
+//		fprintf(stderr, RED "parse() returned NULL!\n" RESET);
+//		return (1);
+//	}
+//	execute(node);
+//}
 

--- a/execute/test/execute_test.c
+++ b/execute/test/execute_test.c
@@ -5,22 +5,77 @@
 
 #define BLUE    "\033[34m"      /* Blue */
 
+void test_split_path_from_env_normal();
+void test_split_path_from_env_colon();
+void print_err_cnt();
+int err_cnt;
+
 int main()
 {
-	t_env_var	*env_vars;
-//	t_executor *e;
+	test_split_path_from_env_normal();
+	test_split_path_from_env_colon();
+	print_err_cnt();
+}
 
+void test_split_path_from_env_normal()
+{
+	t_env_var	*env_vars;
+	char		*path_from_env;
+	char		**paths;
+	char		**expected;
+
+	// basic test (w/o :)
 	env_vars = init_env_lst();
 	if (register_env_var(ft_strdup("?"), ft_strdup("0"), &env_vars) == MALLOC_ERROR)
 		exit(delete_env_lst(env_vars, NULL, NULL));
-//	if (!new_executor(&e, NULL, &env_vars))
-//		exit(EXIT_FAILURE);
-	char *path_from_env = get_env_value("PATH", env_vars);
-	char **paths = split_path_from_env(path_from_env);
-	for (int i = 0; paths[i]; i++) {
-		printf("paths[%d]: %s \n", i, paths[i]);
+	path_from_env = get_env_value("PATH", env_vars);
+	paths = split_path_from_env(path_from_env);
+	expected = ft_split(path_from_env, ':');
+
+	for (int i = 0; expected[i]; i++) {
+		if (ft_strcmp(expected[i], paths[i]))
+		{
+			printf("expected=%s got=%s\n", expected[i], paths[i]);
+			err_cnt++;
+		}
 	}
-//	get_cmd_path(e, "cat")
+	free_2d_array((void ***) &paths);
+	free_2d_array((void ***) &expected);
+	delete_env_lst(env_vars, NULL, NULL);
+	env_vars = NULL;
+	path_from_env = NULL;
+	paths = NULL;
+	system("leaks a.out");
+
+}
+
+void test_split_path_from_env_colon()
+{
+	char *path_from_env = ft_strdup(":hello::test:test:test::");
+	char *cur_path = getcwd(NULL, 0);
+	char *expected[10] = {cur_path, "hello", cur_path, "test", "test", "test", cur_path, cur_path, NULL };
+
+	char **paths = split_path_from_env(path_from_env);
+	for (int i = 0; expected[i]; i++) {
+		if (ft_strcmp(expected[i], paths[i]))
+		{
+			printf("expected=%s got=%s\n", expected[i], paths[i]);
+			err_cnt++;
+		}
+	}
+	free_2d_array((void ***) &paths);
+	free(cur_path);
+	free(path_from_env);
+	path_from_env = NULL;
+	paths = NULL;
+	system("leaks a.out");
+}
+
+void print_err_cnt() {
+	if (err_cnt == 0)
+		printf(BLUE "TOTAL ERROR COUNT: 0 \n" RESET);
+	else
+		printf(RED "TOTAL ERROR COUNT: %d \n" RESET, err_cnt);
 }
 
 //int main(int argc, char **argv) {

--- a/libft/ft_strjoin.c
+++ b/libft/ft_strjoin.c
@@ -1,0 +1,26 @@
+#include "libft.h"
+
+char	*ft_strjoin(char const *s1, char const *s2)
+{
+	size_t	len_s1;
+	size_t	len_s2;
+	char	*rtn;
+	size_t	i;
+
+	if (!s1 || !s2)
+		return (NULL);
+	len_s1 = ft_strlen(s1);
+	len_s2 = ft_strlen(s2);
+	rtn = (char *)malloc(sizeof(char) * (len_s1 + len_s2 + 1));
+	if (!rtn)
+		return ((void *)0);
+	i = 0;
+	len_s1 = 0;
+	while (s1[len_s1])
+		rtn[i++] = s1[len_s1++];
+	len_s2 = 0;
+	while (s2[len_s2])
+		rtn[i++] = s2[len_s2++];
+	rtn[i] = '\0';
+	return (rtn);
+}

--- a/libft/ft_substr.c
+++ b/libft/ft_substr.c
@@ -9,10 +9,10 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 	if (!s)
 		return (NULL);
 	len_s = ft_strlen(s);
-	if (len_s < (start + len) && start < len_s)
-		len = len_s - start;
-	else if (start >= len_s)
+	if (start >= len_s)
 		return (ft_calloc(1, sizeof(char)));
+	if (len_s < (start + len))
+		len = len_s - start;
 	rtn = (char *)ft_calloc(len + 1, sizeof(char));
 	if (!rtn)
 		return (NULL);


### PR DESCRIPTION
## Purpose

使用禁止関数`execvp`の代わりに`execve`の使用
- PATHを見に行くための `get_cmd_path()`を実装
- 下記のリファレンスにあるように `:`はデリミターであるだけではなく、二つ連続した時にはカレントディレクトリを意味する -> `ft_split()`が使えない -> `ft_split()`にコロンが連続した時に、カレントディレクトリを挿入する機能を追加した関数`split_path_from_env()`を追加（`ft_split`はsyamashiさんに教わった少しおしゃれな方法で実装！） 

```
A zero-length (null) directory name in the value of PATH indicates the current directory. A null directory name may appear as two adjacent colons, or as an initial or trailing colon.
```
- その他エラーメッセージなどの細かい実装はこちらを参照していただければと思うのですが、自分も完全には理解していないので、軽く見る感じでお願いします！今度一緒に作業する時にでもわかりやすく説明できるようにしておきます！

## Test

```
$ cd /minishell/execute/test
$ make
```

## Memo
- 現状、`argv[0]`に`path`を入れているが、もしかしたらダメかもしれない...実験しておきます
- テストしながら気づいたのですが、最初にノンブロッキングの`read`入れたせいで`cat`コマンドが使えなくなってるかもです笑笑直しておきます！