### PR TITLE
[軽PR]`export`のバグ修正

### DIFF
--- a/builtin/builtin_export.c
+++ b/builtin/builtin_export.c
@@ -17,7 +17,7 @@ size_t	env_vars_len(t_env_var *env_vars)
 	len = 0;
 	while (env_vars)
 	{
-		if (ft_strcmp("_", env_vars->key))
+		if (ft_strcmp("_", env_vars->key) && ft_strcmp("?", env_vars->key))
 			len++;
 		env_vars = env_vars->next;
 	}
@@ -95,18 +95,18 @@ int	builtin_export(int argc, char **argv, int no_use, t_env_var **env_vars)
 	int		exit_status;
 
 	(void)no_use;
-	value = NULL;
 	exit_status = EXIT_SUCCESS;
 	if (argc == 1)
 		return (print_declaration(*env_vars));
 	i = 1;
 	while (i < argc)
 	{
+		value = NULL;
 		if (is_valid_argument(argv[i], key_strlen(argv[i]), EXPORT_ARG_ERROR))
 		{
 			if (set_key_value(&key, &value, argv[i]) == MALLOC_ERROR)
 				return (BUILTIN_MALLOC_ERROR);
-			else if (register_env_var(key, value, env_vars) == MALLOC_ERROR)
+			if (register_env_var(key, value, env_vars) == MALLOC_ERROR)
 				return (BUILTIN_MALLOC_ERROR);
 		}
 		else


### PR DESCRIPTION
## Purpose
- `export`だけ入力した際にSEGVするケースについて
	- 終了ステータスとして環境変数に追加した`?`を、`declare -x`で表示する際に有効な環境変数の数をカウントする`env_vars_len()`が`?`も数に入れてしまっていため、余分なところまで読んでしまい`quick_sort()`中の`ft_strcmp()`に`NULL`が渡されてSEGVしていた。
	- そのため、`env_vars_len()`が`?`もカウントしないように修正。

- `export str= str2`と入力した際に以下のようになるケースについて
	- 本来、`str2`には`=`がないため、`value`として`NULL`が入る必要があるが、できていなかった。
	- `builtin_export()`のループの外で`value=NULL;`と初期化していたため、1個目の`str=`で`set_key_value()`された際に、`value=""`のまま処理が進んでしまい、`str2=""`と空文字が入ってしまっていた。
	- `value`初期化をループ内に入れて、毎回`value=NULL`の状態から処理できるようにした。
```bash
$ export str= str2
$ export
...
declare -x str=""
declare -x str2=""
...
```

## Effect
- `export str= str2 && export | grep str`のテストケースが通る！
- `export`のSEGVしなくなったので、テストしやすいよ！


## Memo
- `expansion`の`'',""`問題も後でPR投げます〜〜！！（`echo`のせいじゃなかったです。ごめんなさい笑）
