### PR TITLE
`lexer`のメモリーリークとクオートで閉じられてない文字列の処理を追加

### DIFF
--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -57,7 +57,7 @@ t_token	*new_token_newline(t_lexer *l)
 
 	newline_num = 0;
 	newline_type = ILLEGAL;
-	while (l->ch != '\n')
+	while (l->ch == '\n')
 	{
 		read_char(l);
 		newline_num++;

--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -24,7 +24,9 @@ t_token	*new_token_string(t_lexer *l)
 	t_token			*token;
 	const size_t	len_start = l->position;
 	char			quote_type;
+	bool			closed;
 
+	closed = true;
 	token = (t_token *)malloc(sizeof(t_token));
 	if (!token)
 		return (NULL);
@@ -36,12 +38,17 @@ t_token	*new_token_string(t_lexer *l)
 			read_char(l);
 			while (l->ch != quote_type && l->ch != '\0')
 				read_char(l);
+			if (l->ch == '\0')
+				closed = false;
 		}
 		read_char(l);
 		if (l->is_subshell && l->ch == '\n')
 			break ;
 	}
-	token->type = STRING;
+	if (closed)
+		token->type = STRING;
+	else
+		token->type = ILLEGAL;
 	token->literal.len = l->position - len_start;
 	token->literal.start = &(l->input[len_start]);
 	token->next = NULL;

--- a/lexer/lexer_utils.c
+++ b/lexer/lexer_utils.c
@@ -23,7 +23,10 @@ t_token	*skip_space(t_lexer *l)
 	while (ft_isspace(l->ch))
 	{
 		if ((l->is_subshell || l->is_redirect) && l->ch == '\n')
+		{
 			token = new_token_newline(l);
+			return (token);
+		}
 		read_char(l);
 	}
 	l->is_redirect = false;

--- a/lexer/test/Makefile
+++ b/lexer/test/Makefile
@@ -12,7 +12,8 @@ OBJS    		= $(addprefix $(OBJDIR)/, $(notdir $(SRCS:%.c=%.o)))
 LEXER_OBJS		= $(addprefix $(LEXER_OBJDIR)/, $(notdir $(LEXER_SRCS:%.c=%.o)))
 
 CC      = gcc
-CFLAG   = -Wall -Wextra -Werror -fsanitize=address
+# CFLAG   = -Wall -Wextra -Werror -fsanitize=address
+CFLAG   = -Wall -Wextra -Werror
 
 LIBFT_PATH = ../../libft
 INCLUDE		= -I../../lexer -I../../token

--- a/lexer/test/lexer_test.c
+++ b/lexer/test/lexer_test.c
@@ -188,11 +188,11 @@ int main()
 		char input[] = "echo \'hello";
 		struct test test[] = {
 				{STRING, "echo"},
-				{STRING, "\'hello"},
+				{ILLEGAL, "\'hello"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
 		};
-		compare_literal_and_type(input, debug_token_type, STRING, test);
+		compare_literal_and_type(input, debug_token_type, ILLEGAL, test);
 	}
 
 	{
@@ -221,22 +221,22 @@ int main()
 		char input[] = "echo \"hello";
 		struct test test[] = {
 				{STRING, "echo"},
-				{STRING, "\"hello"},
+				{ILLEGAL, "\"hello"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
 		};
-		compare_literal_and_type(input, debug_token_type, STRING, test);
+		compare_literal_and_type(input, debug_token_type, ILLEGAL, test);
 	}
 
 	{
 		char input[] = "echo \"$PATH";
 		struct test test[] = {
 				{STRING, "echo"},
-				{STRING, "\"$PATH"},
+				{ILLEGAL, "\"$PATH"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
 		};
-		compare_literal_and_type(input, debug_token_type, STRING, test);
+		compare_literal_and_type(input, debug_token_type, ILLEGAL, test);
 	}
 	
 	{

--- a/lexer/test/lexer_test.c
+++ b/lexer/test/lexer_test.c
@@ -533,6 +533,7 @@ int main()
 				{STRING, "echo"},
 				{SUBSHELL_NEWLINE_MS, "\n"},
 				{STRING, "$PATH"},
+				{SUBSHELL_NEWLINE_MS, "\n"},
 				{RPAREN, ")"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
@@ -563,6 +564,7 @@ int main()
 				{SUBSHELL_NEWLINE_MS, "\n\n\n"},
 				{STRING, "echo"},
 				{STRING, "hello"},
+				{SUBSHELL_NEWLINE_MS, "\n\n\n"},
 				{RPAREN, ")"},
 				{EOL, "\0"},
 				{TEST_EOL, ""},
@@ -605,7 +607,7 @@ int main()
 				{STRING, "echo"},
 				{STRING, "hello"},
 				{REDIRECT_APPEND, ">>"},
-				{NEWLINE_MS, "\n"},
+				{NEWLINE_MS, "\n\n"},
 				{STRING, "cd"},
 				{STRING, ".."},
 				{EOL, "\0"},
@@ -629,6 +631,8 @@ int main()
 		};
 		compare_literal_and_type(input, debug_token_type, NEWLINE_MS, test);
 	}
+
+	system("leaks a.out");
 
 }
 


### PR DESCRIPTION
- Fix: lexer memory leaks
- Update: new_token_string() returns ILLEGAL token when unclosed quotes are ented

## Purpose
- 改行`\n`が複数回きた際に、以下のように`new_token_newline()`内のループを回す条件が間違っていたため、改行一つ一つに対してtokenを生成していた。
- そのため、複数回の改行がきた時は、最後の一個しかtokenのリストに反映されず、残りのtokenがリークしてしまっていた。
```c
t_token	*new_token_newline(t_lexer *l)
{
	...
	while (l->ch != '\n') // <- チンカス条件文
	{
		read_char(l);
		newline_num++;
	}
	...
}
```

- `', "`で閉じられていない入力が来た際は、大体こんな感じで`ILLEGAL`tokenを返すようにした。
```c
t_token	*new_token_string(t_lexer *l)
{
	...
	bool			closed;

	closed = true;
	...
		if (l->ch == '\'' || l->ch == '\"')
		{
			quote_type = l->ch;
			read_char(l);
			while (l->ch != quote_type && l->ch != '\0')
				read_char(l);
			if (l->ch == '\0')
				closed = false;
		}
	...
	if (closed)
		token->type = STRING;
	else
		token->type = ILLEGAL;
```

## Effect
- lexerのリークなくなったぞーーーー！！
- parserのリークチェックが正しく行える.
- 閉じられてない引用符が入力されてもSEGVしない！(`ILLEGAL`tokenを無視してコマンド実行できるので、`閉じられてない引用符は解釈しない`という要件も満たせているのでは！？)
```bash
minishell> echo "hello

minishell> echo hello "world
hello
minishell> ls 'res
Makefile        minishell       res1
ast             minishell.c     res2
builtin         minishell.h     resssss
env             obj             test
execute         parser          token
expander        res             utils
lexer           res res2
libft           res*
```

## Memo
- もっと早くリーク気づくべきだった。。。。