### PR TITLE
register_env_var()の文字列リテラルと整数リテラルを取れるラッパー関数の作成

### DIFF
--- a/env/env.h
+++ b/env/env.h
@@ -27,6 +27,6 @@ char		*get_env_value(char *key, t_env_var *env_var);
 int			register_env_var(char *key, char *value, t_env_var **env_vars);
 
 // register_env_var_from_literal.c
-int			register_env_var_from_literal(const char *literal_key, const char *literal_value, t_env_var **env_vars);
+int			register_env_var_from_literal(const char *str_key, const char *str_value, int num_value, t_env_var **env_vars);
 
 #endif

--- a/env/env.h
+++ b/env/env.h
@@ -26,4 +26,7 @@ t_env_var	*init_env_lst(void);
 char		*get_env_value(char *key, t_env_var *env_var);
 int			register_env_var(char *key, char *value, t_env_var **env_vars);
 
+// register_env_var_from_literal.c
+int			register_env_var_from_literal(const char *literal_key, const char *literal_value, t_env_var **env_vars);
+
 #endif

--- a/env/register_env_var_from_literal.c
+++ b/env/register_env_var_from_literal.c
@@ -1,0 +1,15 @@
+#include "env.h"
+
+int	register_env_var_from_literal(const char *literal_key, const char *literal_value, t_env_var **env_vars)
+{
+	char	*key;
+	char	*value;
+
+	key = ft_strdup(literal_key);
+	if (!key)
+		perror_exit("malloc", EXIT_FAILURE);
+	value = ft_strdup(literal_value);
+	if (!value)
+		perror_exit("malloc", EXIT_FAILURE);
+	return (register_env_var(key, value, env_vars));
+}

--- a/env/register_env_var_from_literal.c
+++ b/env/register_env_var_from_literal.c
@@ -1,14 +1,17 @@
 #include "env.h"
 
-int	register_env_var_from_literal(const char *literal_key, const char *literal_value, t_env_var **env_vars)
+int	register_env_var_from_literal(const char *str_key, const char *str_value, int num_value, t_env_var **env_vars)
 {
 	char	*key;
 	char	*value;
 
-	key = ft_strdup(literal_key);
+	key = ft_strdup(str_key);
 	if (!key)
 		perror_exit("malloc", EXIT_FAILURE);
-	value = ft_strdup(literal_value);
+	if (!str_value)
+		value = ft_itoa(num_value);
+	else
+		value = ft_strdup(str_value);
 	if (!value)
 		perror_exit("malloc", EXIT_FAILURE);
 	return (register_env_var(key, value, env_vars));

--- a/execute/execute_init.c
+++ b/execute/execute_init.c
@@ -22,8 +22,6 @@ int	execute(t_ast_node *root, t_env_var **env_vars)
 
 int command_line(t_executor *e, t_ast_node *node)
 {
-	char	*key;
-	char	*value;
 	if (node->type == AND_IF_NODE || node->type == OR_IF_NODE)
 	{
 		if (is_execute_condition(e->condition, e->exit_status))
@@ -31,11 +29,7 @@ int command_line(t_executor *e, t_ast_node *node)
 			pipeline(e, &e->pipeline, node->left);
 			e->exit_status = execute_pipeline(e, e->pipeline);
 			//todo: null check
-			key = ft_strdup("?");
-			if (!key) {}
-			value = ft_itoa(e->exit_status);
-			if (!value) {}
-			if (register_env_var(key, value, e->env_vars) == MALLOC_ERROR) {}
+			if (register_env_var_from_literal("?", NULL, e->exit_status, e->env_vars) == MALLOC_ERROR) {}
 			delete_list(e->pipeline, T_PIPELINE);
 		}
 		if (node->type == AND_IF_NODE)
@@ -50,11 +44,7 @@ int command_line(t_executor *e, t_ast_node *node)
 		{
 			pipeline(e, &e->pipeline, node);
 			e->exit_status = execute_pipeline(e, e->pipeline);
-			key = ft_strdup("?");
-			if (!key) {}
-			value = ft_itoa(e->exit_status);
-			if (!value) {}
-			if (register_env_var(key, value, e->env_vars) == MALLOC_ERROR) {}
+			if (register_env_var_from_literal("?", NULL, e->exit_status, e->env_vars) == MALLOC_ERROR) {}
 			delete_list(e->pipeline, T_PIPELINE);
 		}
 		return (e->exit_status);

--- a/minishell.c
+++ b/minishell.c
@@ -49,7 +49,7 @@ int minishell(char *line)
 
 	env_vars = init_env_lst();
 
-	if (register_env_var_from_literal("?", "0", &env_vars) == MALLOC_ERROR)
+	if (register_env_var_from_literal("?", "0", 0, &env_vars) == MALLOC_ERROR)
 		exit(delete_env_lst(env_vars, NULL, NULL));
 	if (line)
 		exit(execute(parse(lex(line)), &env_vars));

--- a/minishell.c
+++ b/minishell.c
@@ -49,8 +49,7 @@ int minishell(char *line)
 
 	env_vars = init_env_lst();
 
-	// todo: null check
-	if (register_env_var(ft_strdup("?"), ft_strdup("0"), &env_vars) == MALLOC_ERROR)
+	if (register_env_var_from_literal("?", "0", &env_vars) == MALLOC_ERROR)
 		exit(delete_env_lst(env_vars, NULL, NULL));
 	if (line)
 		exit(execute(parse(lex(line)), &env_vars));


### PR DESCRIPTION
## Purpose

`register_env_var()`のラッパー関数`register_env_var_from_literal()`を作成

## Effect

こんな感じでリテラルのまま渡せるようになり、コードの簡素化・可読性の向上
```
register_env_var_from_literal("?", NULL, 0, env_vars);
```
