### PR TITLE
【軽PR】malloc周りのラッパー関数の追加！

### DIFF
--- a/execute/create_envp.c
+++ b/execute/create_envp.c
@@ -1,4 +1,5 @@
 #include "execute.h"
+#include "../wrapper/x.h"
 
 static bool is_valid_envp_elem(t_env_var *env_var)
 {
@@ -25,22 +26,13 @@ char	**create_envp(t_executor *e)
 	t_env_var	*iterator;
 	int			index;
 
-	envp = malloc(sizeof(*envp) * (count_env_vars(*e->env_vars) + 1));
-	if (!envp)
-		exit(EXIT_FAILURE); //free
+	envp = x_malloc(sizeof(*envp) * (count_env_vars(*e->env_vars) + 1));
 	iterator = *e->env_vars;
 	index = -1;
 	while (iterator)
 	{
 		if (is_valid_envp_elem(iterator))
-		{
 			envp[++index] = strjoin_three(iterator->key, "=", iterator->value);
-			if (!envp[index])
-			{
-				free_2d_array((void ***) &envp);
-				exit(EXIT_FAILURE); //free
-			}
-		}
 		iterator = iterator->next;
 	}
 	envp[++index] = NULL;

--- a/execute/execute.h
+++ b/execute/execute.h
@@ -20,7 +20,6 @@
 # define CHILD_PROCESS 0
 
 # define CHILD_PROCESS_NOT_CREATED 0
-# define NOT_LAST_COMMAND 0
 
 typedef struct s_pipeline		t_pipeline;
 typedef struct s_subshell		t_subshell;
@@ -93,25 +92,25 @@ struct s_redirect_in {
 int		execute(t_ast_node *root, t_env_var **env_vars);
 void	init_compound_list(t_executor *e, t_compound_list **cl, t_ast_node *node);
 // execute_init_utils.c
-bool	new_t_pipeline(t_pipeline **pipeline);
-bool	new_t_subshell(t_subshell **ss);
-bool	new_t_compound_list(t_compound_list **cl);
-bool	new_t_simple_command(t_simple_command **sc);
-bool	new_argv(t_simple_command *sc);
+void	new_t_pipeline(t_pipeline **pipeline);
+void	new_t_subshell(t_subshell **ss);
+void	new_t_compound_list(t_compound_list **cl);
+void	new_t_simple_command(t_simple_command **sc);
+void	new_argv(t_simple_command *sc);
 
 
 // execute_utils.c
-bool	new_executor(t_executor **e, t_ast_node *root, t_env_var **env_vars);
+void	new_executor(t_executor **e, t_ast_node *root, t_env_var **env_vars);
 void	delete_executor(t_executor **e);
-int		ex_perror(t_executor *e, const char *s);
+//int		ex_perror(t_executor *e, const char *s);
 void	delete_list(void *element, t_list_type type);
 bool	execute_builtin(t_executor *e, int argc, char **argv, bool islast);
 bool	is_execute_condition(int condition, int exit_status);
 void	execute_redirect(t_simple_command *sc);
 
 // new_redirect.c
-bool	new_t_redirect_out(t_simple_command *sc, char *filename, t_node_type type);
-bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_type type);
+void	new_t_redirect_out(t_simple_command *sc, char *filename, t_node_type type);
+void	new_t_redirect_in(t_simple_command *sc, char *data, t_node_type type);
 
 // execute_command.c
 int		execute_pipeline(t_executor *e, t_pipeline *c);

--- a/execute/execute_init_utils.c
+++ b/execute/execute_init_utils.c
@@ -1,61 +1,46 @@
 #include "execute.h"
+#include "../wrapper/x.h"
 
-bool	new_t_pipeline(t_pipeline **pipeline)
+void	new_t_pipeline(t_pipeline **pipeline)
 {
-	*pipeline = malloc(sizeof(**pipeline));
-	if (!*pipeline)
-		return (false);
+	*pipeline = x_malloc(sizeof(**pipeline));
 	(*pipeline)->command = NULL;
 	(*pipeline)->type = UNSET;
 	(*pipeline)->next = NULL;
-	return (true);
 }
 
-bool	new_t_subshell(t_subshell **ss)
+void	new_t_subshell(t_subshell **ss)
 {
-	*ss = malloc(sizeof(**ss));
-	if (!*ss)
-		return (false);
+	*ss = x_malloc(sizeof(**ss));
 	(*ss)->compound_list = NULL;
-	return (true);
 }
 
-bool	new_t_compound_list(t_compound_list **cl)
+void	new_t_compound_list(t_compound_list **cl)
 {
-	*cl = malloc(sizeof(**cl));
-	if (!*cl)
-		return (false);
-	 // (*cl)->condition will not be used w/ being initialized in init_compound_list()
+	*cl = x_malloc(sizeof(**cl));
 	(*cl)->pipeline = NULL;
 	(*cl)->compound_list_next = NULL;
 	(*cl)->next = NULL;
-	return (true);
 }
 
-bool	new_t_simple_command(t_simple_command **sc)
+void	new_t_simple_command(t_simple_command **sc)
 {
-	*sc = (t_simple_command *) malloc(sizeof(**sc));
-	if (!(*sc))
-		return (false);
+	*sc = x_malloc(sizeof(**sc));
 	(*sc)->root = NULL;
 	(*sc)->argc = 0;
 	(*sc)->argv = NULL;
 	(*sc)->r_out = NULL;
 	(*sc)->r_in = NULL;
 	(*sc)->err = NO_ERR;
-	return (true);
 }
 
-bool	new_argv(t_simple_command *sc)
+void	new_argv(t_simple_command *sc)
 {
 	t_ast_node	*node;
 	int			i;
 
 	node = sc->root;
-	// todo: free required!
-	sc->argv = malloc(sizeof(*sc->argv) * (sc->argc + 1));
-	if (!sc->argv)
-		return (false);
+	sc->argv = x_malloc(sizeof(*sc->argv) * (sc->argc + 1));
 	i = 0;
 	while (node != NULL)
 	{
@@ -64,6 +49,5 @@ bool	new_argv(t_simple_command *sc)
 		node = node->right;
 	}
 	sc->argv[i] = NULL;
-	return (true);
 }
 

--- a/execute/execute_utils.c
+++ b/execute/execute_utils.c
@@ -1,16 +1,14 @@
 #include "execute.h"
+#include "../wrapper/x.h"
 
-bool	new_executor(t_executor **e, t_ast_node *root, t_env_var **env_vars)
+void	new_executor(t_executor **e, t_ast_node *root, t_env_var **env_vars)
 {
-	*e = (t_executor *)malloc(sizeof(**e));
-	if (!*e)
-		return (false);
+	*e = (t_executor *)x_malloc(sizeof(**e));
 	(*e)->root = root;
 	(*e)->exit_status = EXIT_SUCCESS;
 	(*e)->condition = CONDITION_AND_IF;
 	(*e)->pipeline = NULL;
 	(*e)->env_vars = env_vars;
-	return (true);
 }
 
 void	delete_executor(t_executor **e)
@@ -58,13 +56,13 @@ void	delete_list(void *element, t_list_type type)
 	free(element);
 }
 
-int	ex_perror(t_executor *e, const char *s)
-{
-	perror(s);
-	if (e)
-		delete_executor(&e);
-	return (EXIT_FAILURE);
-}
+//int	ex_perror(t_executor *e, const char *s)
+//{
+//	perror(s);
+//	if (e)
+//		delete_executor(&e);
+//	return (EXIT_FAILURE);
+//}
 
 static void execute_builtin_internal(int argc, char **argv, t_executor *e, bool islast, int (*fn)(int, char**, int, t_env_var**))
 {

--- a/execute/get_cmd_path.c
+++ b/execute/get_cmd_path.c
@@ -1,4 +1,5 @@
 #include "get_cmd_path.h"
+#include "../wrapper/x.h"
 
 static void	destroy_sep_list(t_sep_list *head)
 {
@@ -16,9 +17,7 @@ static t_sep_list *new_sep_list(int sep_index)
 {
 	t_sep_list	*new;
 
-	new = malloc(sizeof(*new));
-	if (!new)
-		perror_exit("malloc", EXIT_FAILURE);
+	new = x_malloc(sizeof(*new));
 	new->next = NULL;
 	new->sep_index = sep_index;
 	return (new);
@@ -37,11 +36,9 @@ static void create_paths(char **paths, const char *path_from_env, t_sep_list *se
 	{
 		len = sep_list->sep_index - start - 1;
 		if (len == 0)
-			paths[++i] = ft_strdup(".");
+			paths[++i] = x_strdup(".");
 		else
-			paths[++i] = ft_substr(path_from_env, start + 1, len);
-		if (!paths[i])
-			perror_exit("malloc", EXIT_FAILURE);
+			paths[++i] = x_substr(path_from_env, start + 1, len);
 		start = sep_list->sep_index;
 		sep_list = sep_list->next;
 	}
@@ -78,9 +75,7 @@ char **split_path_from_env(const char *path_from_env)
 	int			list_len;
 
 	sep_list = create_sep_list(path_from_env, &list_len);
-	paths = malloc(sizeof(*paths) * (list_len + 1));
-	if (!paths)
-		perror_exit("malloc", EXIT_FAILURE);
+	paths = x_malloc(sizeof(*paths) * (list_len + 1));
 	create_paths(paths, path_from_env, sep_list);
 	destroy_sep_list(sep_list);
 	return (paths);
@@ -95,10 +90,10 @@ char	*get_cmd_path(t_executor *e, char *command)
 
 	path_from_env = get_env_value("PATH", *e->env_vars);
 	if (!path_from_env)
-		return (ft_strdup(command));
+		return (x_strdup(command));
 	paths = split_path_from_env(path_from_env);
 	if (!paths[0])
-		return (ft_strdup(command));
+		return (x_strdup(command));
 	i = -1;
 	while (1)
 	{

--- a/execute/new_redirect.c
+++ b/execute/new_redirect.c
@@ -1,16 +1,15 @@
 #include "execute.h"
 #include "../utils/get_next_line.h"
+#include "../wrapper/x.h"
 
-bool	new_t_redirect_out(t_simple_command *sc, char *filename, t_node_type type)
+void	new_t_redirect_out(t_simple_command *sc, char *filename, t_node_type type)
 {
 	t_redirect_out	**r_out;
 
 	r_out = &sc->r_out;
 	while (*r_out)
 		r_out = &(*r_out)->next;
-	*r_out = malloc(sizeof(**r_out));
-	if (!*r_out)
-		return (false);
+	*r_out = x_malloc(sizeof(**r_out));
 	if (type == REDIRECT_OUT_NODE)
 		(*r_out)->fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 00644);
 	else
@@ -22,21 +21,9 @@ bool	new_t_redirect_out(t_simple_command *sc, char *filename, t_node_type type)
 		sc->err = REDIRECT_ERR;
 	}
 	(*r_out)->next = NULL;
-	return (true);
 }
 
-static void process_gnl_error(t_executor *e, t_gnl_status status, char *line)
-{
-	if (status == GNL_STATUS_ERROR_MALLOC)
-		exit(ex_perror(e, "minishell: malloc"));
-	if (status == GNL_STATUS_ERROR_READ)
-	{
-		free(line);
-		exit(ex_perror(e, "minishell: read"));
-	}
-}
-
-bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_type type)
+void	new_t_redirect_in(t_simple_command *sc, char *data, t_node_type type)
 {
 	int pipefd[2];
 	int status;
@@ -46,9 +33,7 @@ bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_t
 	r_in = &sc->r_in;
 	while (*r_in)
 		r_in = &(*r_in)->next;
-	*r_in = malloc(sizeof(**r_in));
-	if (!*r_in)
-		return (false);
+	*r_in = x_malloc(sizeof(**r_in));
 	if (type == REDIRECT_IN_NODE)
 	{
 		(*r_in)->fd = open(data, O_RDONLY);
@@ -61,12 +46,11 @@ bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_t
 	}
 	else if (type == HEREDOC_NODE)
 	{
-		pipe(pipefd);
+		x_pipe(pipefd);
 		while (1)
 		{
 			ft_putstr_fd("> ", STDOUT_FILENO);
-			status = get_next_line(STDIN_FILENO, &line);
-			process_gnl_error(e, status, line);
+			status = x_get_next_line(STDIN_FILENO, &line);
 			if (status == GNL_STATUS_DONE || !ft_strcmp(line, data))
 				break ;
 			ft_putendl_fd(line, pipefd[WRITE]);
@@ -77,5 +61,4 @@ bool	new_t_redirect_in(t_executor *e, t_simple_command *sc, char *data, t_node_t
 		(*r_in)->fd = pipefd[READ];
 	}
 	(*r_in)->next = NULL;
-	return (true);
 }

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -18,7 +18,7 @@
 typedef struct t_parser {
 	t_token *token;
 	int		err;
-	t_bool	is_subshell;
+	bool	is_subshell;
 }	t_parser;
 
 // parser.c

--- a/wrapper/wrapper.h
+++ b/wrapper/wrapper.h
@@ -1,9 +1,0 @@
-#ifndef WRAPPER_H
-#define WRAPPER_H
-
-int		ms_dup(int fildes);
-int		ms_dup2(int fildes, int fildes2);
-pid_t	ms_fork(void);
-int		ms_pipe(int fildes[2]);
-
-#endif //WRAPPER_H

--- a/wrapper/x.h
+++ b/wrapper/x.h
@@ -1,0 +1,13 @@
+#ifndef WRAPPER_H
+#define WRAPPER_H
+
+int		x_dup(int fildes);
+int		x_dup2(int fildes, int fildes2);
+pid_t	x_fork(void);
+int		x_pipe(int fildes[2]);
+void	*x_malloc(size_t size);
+int		x_get_next_line(int fd, char **line);
+char	*x_substr(char const *s, unsigned int start, size_t len);
+char	*x_strdup(const char *str);
+
+#endif //WRAPPER_H

--- a/wrapper/x_dup.c
+++ b/wrapper/x_dup.c
@@ -2,7 +2,7 @@
 
 #include "../utils/utils.h"
 
-int	ms_dup(int fildes)
+int	x_dup(int fildes)
 {
 	int	newfd;
 

--- a/wrapper/x_dup2.c
+++ b/wrapper/x_dup2.c
@@ -2,7 +2,7 @@
 
 #include "../utils/utils.h"
 
-int	ms_dup2(int fildes, int fildes2)
+int	x_dup2(int fildes, int fildes2)
 {
 	int	newfd;
 

--- a/wrapper/x_fork.c
+++ b/wrapper/x_fork.c
@@ -2,7 +2,7 @@
 
 #include "../utils/utils.h"
 
-pid_t	ms_fork(void)
+pid_t	x_fork(void)
 {
 	pid_t	pid;
 

--- a/wrapper/x_get_next_line.c
+++ b/wrapper/x_get_next_line.c
@@ -1,0 +1,13 @@
+#include "../utils/get_next_line.h"
+
+int	x_get_next_line(int fd, char **line)
+{
+	t_gnl_status	status;
+
+	status = get_next_line(fd, line);
+	if (status == GNL_STATUS_ERROR_MALLOC)
+		perror_exit("malloc", EXIT_FAILURE);
+	if (status == GNL_STATUS_ERROR_READ)
+		perror_exit("read", EXIT_FAILURE);
+	return (status);
+}

--- a/wrapper/x_malloc.c
+++ b/wrapper/x_malloc.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+
+#include "../utils/utils.h"
+
+void *x_malloc(size_t size)
+{
+	void	*res;
+
+	res = malloc(size);
+	if (!res)
+		perror_exit("malloc", EXIT_FAILURE);
+	return (res);
+}

--- a/wrapper/x_pipe.c
+++ b/wrapper/x_pipe.c
@@ -2,7 +2,7 @@
 
 #include "../utils/utils.h"
 
-int ms_pipe(int fildes[2])
+int x_pipe(int fildes[2])
 {
 	int	res;
 

--- a/wrapper/x_strdup.c
+++ b/wrapper/x_strdup.c
@@ -1,0 +1,12 @@
+#include "../libft/libft.h"
+#include "../utils/utils.h"
+
+char	*x_strdup(const char *str)
+{
+	char	*res;
+
+	res = ft_strdup(str);
+	if (!res)
+		perror_exit("malloc", EXIT_FAILURE);
+	return (res);
+}

--- a/wrapper/x_substr.c
+++ b/wrapper/x_substr.c
@@ -1,0 +1,12 @@
+#include "../libft/libft.h"
+#include "../utils/utils.h"
+
+char	*x_substr(char const *s, unsigned int start, size_t len)
+{
+	char	*res;
+
+	res = ft_substr(s, start, len);
+	if (!res)
+		perror_exit("malloc", EXIT_FAILURE);
+	return (res);
+}


### PR DESCRIPTION
## Purpose

失敗したら、`perror()`して`exit()`する系の関数は`x_*()`と名付けることに決まったので、それに倣っていくつかの関数の作成

## Effect

標準関数や`libft`関数の後に毎回入っていたエラーチェックがなくなるため、コードの見通しがよくなり可読性が向上！
