### PR TITLE
【超軽PR】`lexer`の`x_malloc()`の引数修正

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -1,18 +1,14 @@
 #include "lexer.h"
 
 // inputに対して新しくlexer構造体を作成する
-t_lexer *new_lexer(char *input)
+void	new_lexer(t_lexer **l, char *input)
 {
-	t_lexer *l;
-
-	// todo: FREE required!!
-	l = x_malloc(sizeof(*l));
-	l->input = input;
-	l->position = 0;
-	l->read_position = 0;
-	l->is_subshell = false;
-	l->is_redirect = false;
-	return l;
+	*l = x_malloc(sizeof(**l));
+	(*l)->input = input;
+	(*l)->position = 0;
+	(*l)->read_position = 0;
+	(*l)->is_subshell = false;
+	(*l)->is_redirect = false;
 }
 
 // token解析のための分岐処理
@@ -91,7 +87,7 @@ t_token	*lex(char *input)
 	t_token	*tmp;
 	t_lexer	*l;
 
-	l = new_lexer(input);
+	new_lexer(&l, input);
 	token.next = NULL;
 	tmp = &token;
 	read_char(l);

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@ t_lexer *new_lexer(char *input)
 	t_lexer *l;
 
 	// todo: FREE required!!
-	l = x_malloc(sizeof(t_lexer));
+	l = x_malloc(sizeof(*l));
 	l->input = input;
 	l->position = 0;
 	l->read_position = 0;

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -30,7 +30,7 @@ typedef struct s_lexer
 }	t_lexer;
 
 // lexer.c
-t_lexer	*new_lexer(char *input);
+void	new_lexer(t_lexer **l, char *input);
 t_token	*next_token(t_lexer *lexer);
 t_token	*lex(char *input);
 

--- a/lexer/lexer_new_token.c
+++ b/lexer/lexer_new_token.c
@@ -4,7 +4,7 @@ t_token	*new_token(t_token_type token_type, t_lexer *l, size_t len, size_t len_s
 {
 	t_token	 *token;
 
-	token = x_malloc(sizeof(t_token));
+	token = x_malloc(sizeof(*token));
 	token->type = token_type;
 	token->literal.start = &(l->input[len_start]);
 	token->literal.len = len;
@@ -23,7 +23,7 @@ t_token	*new_token_string(t_lexer *l)
 	bool			closed;
 
 	closed = true;
-	token = x_malloc(sizeof(t_token));
+	token = x_malloc(sizeof(*token));
 	while (!ft_strchr(DELIMITER, l->ch))
 	{
 		if (l->ch == '\'' || l->ch == '\"')


### PR DESCRIPTION
## Purpose
- [PR#114](https://github.com/tacomea/minishell/pull/114)より `x_malloc(sizeof(t_token))` -> `x_malloc(sizeof(*token))` という形に統一。

## Memo
- `expander`とかもこれでいきます！！