### PR TITLE
`expander`の環境変数展開とワイルドカード展開における`x_*()`の使用

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -1,7 +1,7 @@
 #include <dirent.h>
 #include "expander.h"
 
-t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node);
+void		search_command_arg_node(t_expander *e, t_ast_node *node);
 char		*expand_word(t_expander *e, char delimiter);
 char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
 char		*expand_environment_variable(char *data, size_t replace_starts, t_expander *e, int status);
@@ -18,38 +18,33 @@ t_ast_node	*expand(t_ast_node *root, t_env_var **env_vars, int exit_status)
 	if (!root)
 		return (NULL);
 	new_expander(&e, root, *env_vars);
-	if (!search_command_arg_node(e, root))
-	{
-		free(e);
-		return (NULL);
-	}
+	search_command_arg_node(e, root);
 	free(e);
 	return (root);
 }
 
-t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node)
+void search_command_arg_node(t_expander *e, t_ast_node *node)
 {
 	char		*original_data;
 	t_ast_node	*head;
 
 	head = node;
 	if (!node)
-		return (e->node);
-	if (!search_command_arg_node(e, node->right)
-		|| !search_command_arg_node(e, node->left))
-		return (NULL);
+		return ;
+	search_command_arg_node(e, node->right);
+	search_command_arg_node(e, node->left);
 	if (node->type != COMMAND_ARG_NODE && node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE && node->type != REDIRECT_APPEND_NODE)
-		return (node);
+		return ;
 	original_data = x_strdup(node->data);
 	e->node = node;
 	node->data = expand_word(e, '$');
 	node->data = expand_word(e, '*');
 	node = word_splitting(node, e, original_data);
 	if (!node)
-		return (NULL);
+		return ;
 	free(original_data);
-	return (head);
+	// return (head);
 }
 
 char	*expand_word(t_expander *e, char delimiter)

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -56,8 +56,6 @@ char	*expand_word(t_expander *e, char delimiter)
 	data = e->node->data;
 	if (!data)
 		return (NULL);
-	if (!is_expandable_string(data, delimiter))
-		return (data);
 	i = 0;
 	status = OUTSIDE;
 	while (data[i])

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -54,6 +54,7 @@ char	*expand_word(t_expander *e, char delimiter)
 	size_t	i;
 
 	data = e->node->data;
+	// todo: need this? Is there a possibility that data is NULL?
 	if (!data)
 		return (NULL);
 	i = 0;
@@ -88,9 +89,7 @@ char	*expand_environment_variable(char *data, size_t replace_start, t_expander *
 		value = get_env_value("?", e->env_vars);
 	else
 	{
-		key = malloc(sizeof(char) * (var_len + 1));
-		if (!key)
-			exit(expand_perror(e, "malloc"));
+		key = x_malloc(sizeof(*key) * (var_len + 1));
 		ft_memmove(key, var_start, var_len);
 		key[var_len] = '\0';
 		value = get_env_value(key, e->env_vars);

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -17,8 +17,7 @@ t_ast_node	*expand(t_ast_node *root, t_env_var **env_vars, int exit_status)
 	(void)exit_status;
 	if (!root)
 		return (NULL);
-	if (!new_expander(&e, root, *env_vars))
-		exit(expand_perror(NULL, "malloc"));
+	new_expander(&e, root, *env_vars);
 	if (!search_command_arg_node(e, root))
 	{
 		free(e);
@@ -42,9 +41,7 @@ t_ast_node	*search_command_arg_node(t_expander *e, t_ast_node *node)
 	if (node->type != COMMAND_ARG_NODE && node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE && node->type != REDIRECT_APPEND_NODE)
 		return (node);
-	original_data = ft_strdup(node->data);
-	if (!original_data)
-		exit(expand_perror(e, "malloc"));
+	original_data = x_strdup(node->data);
 	e->node = node;
 	node->data = expand_word(e, '$');
 	node->data = expand_word(e, '*');

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -5,7 +5,7 @@ void		search_command_arg_node(t_expander *e, t_ast_node *node);
 char		*expand_word(t_expander *e, char delimiter);
 char		*expand_quotes_string(char *data, size_t replace_start, char quote_type);
 char		*expand_environment_variable(char *data, size_t replace_starts, t_expander *e, int status);
-char		*expand_wildcard(char *data, size_t pre_len, t_expander *e);
+char		*expand_wildcard(char *data, size_t pre_len);
 t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data);
 char		*remove_quotes(char *data, t_expander *e);
 
@@ -65,7 +65,7 @@ char	*expand_word(t_expander *e, char delimiter)
 		if (data[i] == '$' && delimiter == '$' && status != IN_SINGLE_QUOTE)
 			data = expand_environment_variable(data, i, e, status);
 		else if (data[i] == '*' && delimiter == '*' && status == OUTSIDE)
-			data = expand_wildcard(data, i, e);
+			data = expand_wildcard(data, i);
 		if (!data)
 			return (NULL);
 		if (!data[i])
@@ -101,7 +101,7 @@ char	*expand_environment_variable(char *data, size_t replace_start, t_expander *
 		return (str_insert(data, replace_start, "", 0));
 }
 
-char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
+char	*expand_wildcard(char *data, size_t pre_len)
 {
 	DIR				*dir;
 	struct dirent	*dp;
@@ -120,11 +120,11 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 			continue ;
 		if (is_match_pattern(rtn, pre_len, dp->d_name)
 			&& is_match_pattern(post_start, post_len, ft_strchr(dp->d_name, 0) - post_len))
-			rtn = append_wildcard_strings(rtn, dp->d_name, data, e);
+			rtn = append_wildcard_strings(rtn, dp->d_name, data);
 	}
 	x_closedir(dir);
 	if (rtn != data)
-		rtn = sort_strings(rtn, e, data);
+		rtn = sort_strings(rtn, data);
 	return (rtn);
 }
 

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -29,7 +29,7 @@ void search_command_arg_node(t_expander *e, t_ast_node *node)
 	t_ast_node	*head;
 
 	head = node;
-	if (!node)
+	if (!node || !node->data)
 		return ;
 	search_command_arg_node(e, node->right);
 	search_command_arg_node(e, node->left);
@@ -109,14 +109,12 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 	const size_t	post_len = unquoted_strlen(post_start);
 	char			*rtn;
 
-	dir = opendir(".");
-	if (!dir)
-		exit(expand_perror(e, "opendir"));
+	dir = x_opendir(".");
 	rtn = data;
 	while (1)
 	{
-		dp = readdir(dir);
-		if (!rtn || !dp)
+		dp = x_readdir(dir);
+		if (!dp)
 			break ;
 		if (!ft_strncmp(dp->d_name, ".", 1))
 			continue ;
@@ -124,12 +122,9 @@ char	*expand_wildcard(char *data, size_t pre_len, t_expander *e)
 			&& is_match_pattern(post_start, post_len, ft_strchr(dp->d_name, 0) - post_len))
 			rtn = append_wildcard_strings(rtn, dp->d_name, data, e);
 	}
-	closedir(dir);
+	x_closedir(dir);
 	if (rtn != data)
-	{
-		free(data);
-		rtn = sort_strings(rtn, e);
-	}
+		rtn = sort_strings(rtn, e, data);
 	return (rtn);
 }
 

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -43,7 +43,6 @@ t_ast_node	*expand(t_ast_node *root, t_env_var **env_vars, int exit_status);
 
 // expander_utils.c
 void		new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars);
-bool		is_expandable_string(char *str, char delimiter);
 int			expand_perror(t_expander *e, const char *s);
 void		*expand_redirect_error(char *original_data);
 int			quotation_status(char c, int status);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -56,7 +56,7 @@ bool		is_expandable_env_var(char start, int status);
 char		*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e);
 void		quick_sort(char **array, size_t left, size_t right);
 bool		is_match_pattern(const char *data, size_t len, char *name);
-char		*sort_strings(char *src, t_expander *e);
+char		*sort_strings(char *src, t_expander *e, char *data);
 
 // expander_quote.c
 bool		is_quote(const char c);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -11,6 +11,7 @@
 # include "../utils/utils.h"
 # include "../execute/execute.h"
 # include "../env/env.h"
+# include "../wrapper/x.h"
 
 # include <stdlib.h>
 # include <dirent.h>
@@ -41,7 +42,7 @@ struct s_expander {
 t_ast_node	*expand(t_ast_node *root, t_env_var **env_vars, int exit_status);
 
 // expander_utils.c
-bool		new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars);
+void		new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars);
 bool		is_expandable_string(char *str, char delimiter);
 int			expand_perror(t_expander *e, const char *s);
 void		*expand_redirect_error(char *original_data);

--- a/expander/expander.h
+++ b/expander/expander.h
@@ -53,10 +53,10 @@ char		*str_insert(char *data, size_t replace_start, char *env_value, size_t env_
 bool		is_expandable_env_var(char start, int status);
 
 // expander_wildcard.c
-char		*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e);
+char		*append_wildcard_strings(char *dst, char *src, const char *data);
 void		quick_sort(char **array, size_t left, size_t right);
 bool		is_match_pattern(const char *data, size_t len, char *name);
-char		*sort_strings(char *src, t_expander *e, char *data);
+char		*sort_strings(char *src, char *data);
 
 // expander_quote.c
 bool		is_quote(const char c);

--- a/expander/expander_env.c
+++ b/expander/expander_env.c
@@ -21,9 +21,7 @@ char	*str_insert(char *data, size_t replace_start, char *env_value, size_t env_v
 	char			*expanded_str;
 
 	prev_data = data;
-	expanded_str = (char *)malloc(sizeof(char) * (expansion_len + 1));
-	if (!expanded_str)
-		return (NULL);
+	expanded_str = x_malloc(sizeof(*expanded_str) * (expansion_len + 1));
 	ft_memmove(&expanded_str[0], &data[0], replace_start);
 	ft_memmove(&expanded_str[replace_start], env_value, env_value_len);
 	ft_memmove(&expanded_str[replace_start + env_value_len],

--- a/expander/expander_utils.c
+++ b/expander/expander_utils.c
@@ -1,14 +1,11 @@
 #include "expander.h"
 
-bool	new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars)
+void	new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars)
 {
-	*e = (t_expander *)malloc(sizeof(**e));
-	if (!*e)
-		return (false);
+	*e = x_malloc(sizeof(**e));
 	(*e)->root = root;
 	(*e)->node = root;
 	(*e)->env_vars = env_vars;
-	return (true);
 }
 
 bool	is_expandable_string(char *str, char delimiter)

--- a/expander/expander_utils.c
+++ b/expander/expander_utils.c
@@ -8,13 +8,6 @@ void	new_expander(t_expander **e, t_ast_node *root, t_env_var *env_vars)
 	(*e)->env_vars = env_vars;
 }
 
-bool	is_expandable_string(char *str, char delimiter)
-{
-	if (ft_strchr(str, delimiter))
-		return (true);
-	return (false);
-}
-
 int	expand_perror(t_expander *e, const char *s)
 {
 	perror(s);

--- a/expander/expander_wildcard.c
+++ b/expander/expander_wildcard.c
@@ -3,15 +3,10 @@
 char	*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e)
 {
 	if (dst == data)
-		return (ft_strdup(src));
+		return (x_strdup(src));
 	else
 	{
 		dst = strappend(dst, " ", 1);
-		if (!dst)
-		{
-			free(src);
-			exit(expand_perror(e, "malloc"));
-		}
 		dst = strappend(dst, src, ft_strlen(src));
 		return (dst);
 	}
@@ -27,7 +22,7 @@ bool	is_match_pattern(const char *data, size_t len, char *name)
 	while (i < len)
 	{
 		if (data[i] == '\"' || data[i] == '\'')
-		{
+		{	
 			i++;
 			continue ;
 		}
@@ -74,17 +69,16 @@ void	quick_sort(char **array, size_t left, size_t right)
 		quick_sort(array, j + 1, right);
 }
 
-char	*sort_strings(char *src, t_expander *e)
+char	*sort_strings(char *src, t_expander *e, char *data)
 {
 	char	**wildcard_array;
 	size_t	word_num;
 	char	*rtn;
 	size_t	i;
 
-	wildcard_array = ft_split(src, ' ');
+	free(data);
+	wildcard_array = x_split(src, ' ');
 	free(src);
-	if (!wildcard_array)
-		exit(expand_perror(e, "malloc"));
 	word_num = 0;
 	while (wildcard_array[word_num])
 		word_num++;

--- a/expander/expander_wildcard.c
+++ b/expander/expander_wildcard.c
@@ -1,6 +1,6 @@
 #include "expander.h"
 
-char	*append_wildcard_strings(char *dst, char *src, const char *data, t_expander *e)
+char	*append_wildcard_strings(char *dst, char *src, const char *data)
 {
 	if (dst == data)
 		return (x_strdup(src));
@@ -69,7 +69,7 @@ void	quick_sort(char **array, size_t left, size_t right)
 		quick_sort(array, j + 1, right);
 }
 
-char	*sort_strings(char *src, t_expander *e, char *data)
+char	*sort_strings(char *src, char *data)
 {
 	char	**wildcard_array;
 	size_t	word_num;
@@ -86,7 +86,7 @@ char	*sort_strings(char *src, t_expander *e, char *data)
 	rtn = NULL;
 	i = 0;
 	while (i < word_num)
-		rtn = append_wildcard_strings(rtn, wildcard_array[i++], NULL, e);
+		rtn = append_wildcard_strings(rtn, wildcard_array[i++], NULL);
 	free_2d_array((void ***)&wildcard_array);
 	return (rtn);
 }

--- a/utils/strappend.c
+++ b/utils/strappend.c
@@ -10,6 +10,7 @@ char	*strappend(char *dst, const char *src, size_t l)
 	rtn = (char *)malloc(sizeof(char) * (ft_strlen(dst) + l + 1));
 	if (!rtn)
 		perror_exit("malloc", EXIT_FAILURE);
+	i = 0;
 	j = 0;
 	while (dst[j])
 		rtn[i++] = dst[j++];

--- a/utils/strappend.c
+++ b/utils/strappend.c
@@ -9,11 +9,7 @@ char	*strappend(char *dst, const char *src, size_t l)
 
 	rtn = (char *)malloc(sizeof(char) * (ft_strlen(dst) + l + 1));
 	if (!rtn)
-	{
-		free(dst);
-		return (NULL);
-	}
-	i = 0;
+		perror_exit("malloc", EXIT_FAILURE);
 	j = 0;
 	while (dst[j])
 		rtn[i++] = dst[j++];

--- a/wrapper/x.h
+++ b/wrapper/x.h
@@ -3,15 +3,21 @@
 
 # include <sys/stat.h>
 # include <stdlib.h>
+# include <dirent.h>
+# include "../utils/utils.h"
 
-int		x_dup(int fildes);
-int		x_dup2(int fildes, int fildes2);
-pid_t	x_fork(void);
-int		x_pipe(int fildes[2]);
-void	*x_malloc(size_t size);
-int		x_get_next_line(int fd, char **line);
-char	*x_substr(char const *s, unsigned int start, size_t len);
-char	*x_strdup(const char *str);
-int		x_stat(const char *restrict path, struct stat *restrict buf);
+int				x_dup(int fildes);
+int				x_dup2(int fildes, int fildes2);
+pid_t			x_fork(void);
+int				x_pipe(int fildes[2]);
+void			*x_malloc(size_t size);
+int				x_get_next_line(int fd, char **line);
+char			*x_substr(char const *s, unsigned int start, size_t len);
+char			*x_strdup(const char *str);
+int				x_stat(const char *restrict path, struct stat *restrict buf);
+DIR				*x_opendir(const char *str);
+struct dirent	*x_readdir(DIR *dirp);
+void			x_closedir(DIR *dir);
+char			**x_split(const char *s, char c);
 
 #endif //WRAPPER_H

--- a/wrapper/x_closedir.c
+++ b/wrapper/x_closedir.c
@@ -1,0 +1,10 @@
+#include "x.h"
+
+void	x_closedir(DIR *dir)
+{
+	int	res;
+
+	res = closedir(dir);
+	if (res == -1)
+		perror_exit("closedir", EXIT_FAILURE);
+}

--- a/wrapper/x_opendir.c
+++ b/wrapper/x_opendir.c
@@ -1,0 +1,11 @@
+#include "x.h"
+
+DIR	*x_opendir(const char *str)
+{
+	DIR	*dir;
+
+	dir = opendir(str);
+	if (!dir)
+		perror_exit("opendir", EXIT_FAILURE);
+	return (dir);
+}

--- a/wrapper/x_readdir.c
+++ b/wrapper/x_readdir.c
@@ -1,0 +1,13 @@
+#include "x.h"
+#include <errno.h>
+
+struct dirent	*readdir(DIR *dirp)
+{
+	struct dirent	*dp;
+
+	errno = 0;
+	dp = readdir(dirp);
+	if (!dp && errno != 0)
+		perror_exit("readdir", EXIT_FAILURE);
+	return dp;
+}

--- a/wrapper/x_readdir.c
+++ b/wrapper/x_readdir.c
@@ -1,7 +1,7 @@
 #include "x.h"
 #include <errno.h>
 
-struct dirent	*readdir(DIR *dirp)
+struct dirent	*x_readdir(DIR *dirp)
 {
 	struct dirent	*dp;
 
@@ -9,5 +9,5 @@ struct dirent	*readdir(DIR *dirp)
 	dp = readdir(dirp);
 	if (!dp && errno != 0)
 		perror_exit("readdir", EXIT_FAILURE);
-	return dp;
+	return (dp);
 }

--- a/wrapper/x_split.c
+++ b/wrapper/x_split.c
@@ -1,0 +1,11 @@
+#include "x.h"
+
+char	**x_split(const char *s, char c)
+{
+	char	**split;
+
+	split = ft_split(s, c);
+	if (!split)
+		perror_exit("malloc", EXIT_FAILURE);
+	return (split);
+}


### PR DESCRIPTION
- Update: x_malloc(), x_strdup()
- Update: serch_command_arg_node to void function
- Remove: don't need is_expandable_string() because have quotation_status()
- Update: expand_environment_variable() to use x_malloc()
- Add: new wrapper functions and exit() when strappend() fails
- Update: expand_wildcard() to use x_*() functions
- Fix: function argument, type, name

## Purpose
- `expander`において、`malloc()`を直接使ったり、組み込んだ関数を使うことが多いので、`x_malloc()`などのラッパー関数を使用するようにした。
- 使う場面が多いため、今回は環境変数とワイルドカード展開、この2つのみ変更した。
- `opendir()`などのラッパー関数も新たに作成した。
- この変更に伴い、返り値の`NULL`チェックがほぼ必要なくなったので、関数の型も`void`などに変更した。

## Effect
- `expander`がかなりスッキリした！


## Memo
- この変更に問題なければ、word_splittingとquotes_removalも修正します！
