### PR TITLE
`expander`no

### DIFF
--- a/expander/expander.c
+++ b/expander/expander.c
@@ -22,14 +22,14 @@ static char	*expand_word(t_expander *e, char *data, char delimiter)
 	return (data);
 }
 
-static void	search_command_arg_node(t_expander *e, t_ast_node *node)
+static void	search_expandable_node(t_expander *e, t_ast_node *node)
 {
 	char		*original_data;
 
 	if (!node)
 		return ;
-	search_command_arg_node(e, node->right);
-	search_command_arg_node(e, node->left);
+	search_expandable_node(e, node->right);
+	search_expandable_node(e, node->left);
 	if (node->type != COMMAND_ARG_NODE
 		&& node->type != REDIRECT_IN_NODE
 		&& node->type != REDIRECT_OUT_NODE
@@ -44,6 +44,7 @@ static void	search_command_arg_node(t_expander *e, t_ast_node *node)
 		return ;
 	}
 	node->data = expand_word(e, node->data, '*');
+	// if (!is_valid_expansion(e, ))
 	word_splitting(node, e, original_data);
 	free(original_data);
 }

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -37,15 +37,9 @@ static void	search_expandable_node(t_expander *e, t_ast_node *node)
 		return ;
 	original_data = x_strdup(node->data);
 	node->data = expand_word(e, node->data, '$');
-	if (!*node->data && node->type == COMMAND_ARG_NODE)
-	{
-		node->data = NULL;
-		free(original_data);
-		return ;
-	}
 	node->data = expand_word(e, node->data, '*');
-	// if (!is_valid_expansion(e, ))
-	word_splitting(node, e, original_data);
+	if (is_expandable_data(e, node, original_data))
+		word_splitting(node, e, original_data);
 	free(original_data);
 }
 
@@ -56,7 +50,7 @@ t_ast_node	*expand(t_ast_node *root, t_env_var **env_vars)
 	if (!root)
 		return (NULL);
 	new_expander(&e, *env_vars);
-	search_command_arg_node(e, root);
+	search_expandable_node(e, root);
 	if (e->err != NO_ERR)
 		return (handle_expand_error(e));
 	free(e->err_data);

--- a/expander/expander.c
+++ b/expander/expander.c
@@ -44,7 +44,7 @@ static void	search_command_arg_node(t_expander *e, t_ast_node *node)
 		return ;
 	}
 	node->data = expand_word(e, node->data, '*');
-	node = word_splitting(node, e, original_data);
+	word_splitting(node, e, original_data);
 	free(original_data);
 }
 

--- a/expander/internal/expander_internal.h
+++ b/expander/internal/expander_internal.h
@@ -38,10 +38,10 @@ char		*remove_quotes(char *data);
 
 // expander_utils.c
 void		new_expander(t_expander **e, t_env_var *env_vars);
-int			expand_perror(t_expander *e, const char *s);
 void		expand_redirect_error(char *original_data, t_expander *e);
 int			quotation_status(char c, int status);
 t_ast_node	*handle_expand_error(t_expander *e);
+bool		is_expandable_data(t_expander *e, t_ast_node *node, char *original_data);
 
 // expander_env.c
 size_t		var_strlen(const char *str);

--- a/expander/internal/expander_internal.h
+++ b/expander/internal/expander_internal.h
@@ -39,7 +39,7 @@ char		*remove_quotes(char *data);
 // expander_utils.c
 void		new_expander(t_expander **e, t_env_var *env_vars);
 int			expand_perror(t_expander *e, const char *s);
-t_ast_node	*expand_redirect_error(char *original_data, t_ast_node *node, t_expander *e);
+void		expand_redirect_error(char *original_data, t_expander *e);
 int			quotation_status(char c, int status);
 t_ast_node	*handle_expand_error(t_expander *e);
 
@@ -66,7 +66,6 @@ void		remove_null_argument(char *str);
 
 // expander_splitting.c
 char		**split_by_space_skip_quotes(char const *str, const char *delims);
-t_ast_node	*split_arg_node(char **split, t_ast_node *node, char *original_data, t_expander *e);
-t_ast_node	*word_splitting(t_ast_node *node, t_expander *e, char *original_data);
+void		word_splitting(t_ast_node *node, t_expander *e, char *original_data);
 
 #endif

--- a/expander/internal/expander_utils.c
+++ b/expander/internal/expander_utils.c
@@ -8,18 +8,6 @@ void	new_expander(t_expander **e, t_env_var *env_vars)
 	(*e)->env_vars = env_vars;
 }
 
-// int	expand_perror(t_expander *e, const char *s)
-// {
-// 	perror(s);
-// 	if (e)
-// 	{
-// 		delete_ast_nodes(e->node, NULL);
-// 		delete_env_lst(e->env_vars, NULL, NULL);
-// 	}
-// 	free(e);
-// 	return (EXIT_FAILURE);
-// }
-
 void	expand_redirect_error(char *original_data, t_expander *e)
 {
 	if (e->err != NO_ERR)
@@ -59,4 +47,19 @@ t_ast_node	*handle_expand_error(t_expander *e)
 	free(e->err_data);
 	free(e);
 	return (NULL);
+}
+
+bool	is_expandable_data(t_expander *e, t_ast_node *node, char *original_data)
+{
+	if (!*node->data && node->type == COMMAND_ARG_NODE)
+	{
+		node->data = NULL;
+		return (false);
+	}
+	else if (!*node->data && *original_data && node->type != COMMAND_ARG_NODE)
+	{
+		expand_redirect_error(original_data, e);
+		return (false);
+	}
+	return (true);
 }

--- a/expander/internal/expander_utils.c
+++ b/expander/internal/expander_utils.c
@@ -20,13 +20,12 @@ void	new_expander(t_expander **e, t_env_var *env_vars)
 // 	return (EXIT_FAILURE);
 // }
 
-t_ast_node	*expand_redirect_error(char *original_data, t_ast_node *node, t_expander *e)
+void	expand_redirect_error(char *original_data, t_expander *e)
 {
 	if (e->err != NO_ERR)
 		free(e->err_data);
 	e->err = AMBIGUOUS_REDIRECT_ERR;
 	e->err_data = x_strdup(original_data);
-	return (node);
 }
 
 int	quotation_status(char c, int status)

--- a/expander/internal/expander_wordsplitting.c
+++ b/expander/internal/expander_wordsplitting.c
@@ -138,11 +138,6 @@ void	word_splitting(t_ast_node *node, t_expander *e, char *original_data)
 	char	**split;
 	char	*expand_env_data;
 
-	if (!*node->data && *original_data && node->type != COMMAND_ARG_NODE)
-	{
-		expand_redirect_error(original_data, e);
-		return ;
-	}
 	if (!*node->data)
 		return ;
 	expand_env_data = x_strdup(node->data);

--- a/test/cases/expansion.txt
+++ b/test/cases/expansion.txt
@@ -79,3 +79,7 @@ echo -n a
 echo -n hello world
 echo a "$NO_SUCH_ENV" b $NO_SUCH_ENV c, unset NO_SUCH_ENV
 $HOGE
+export TEST=res && cat < $TEST
+export TEST=res* && cat < $TEST
+export TEST="res res2" && cat < $TEST
+export TEST= && cat < $TEST


### PR DESCRIPTION
- Fix: expand redirection environment variable erorr handling
- Add: expansion testcase
- Update: search_command_arg_node() -> search_expandable_node()
- Update: expandable data check after enxpand env, '*'

## Purpose
- 以下のようなテストケースで、エラーとして判断してはいけないものをエラーとして出力してしまい、SEGVしていたのを修正。
- 環境変数展開後の文字列と、word_splitting後の文字列を比較することで、エラーではない環境変数展開かどうかを判断している。
```bash
$ export TEST=res && cat < $TEST
```

- 環境変数展開、ワイルドカード展開後の文字列のチェックをひとまとめにした。
- この関数が`true`の場合のみ、`word_splitting()`が実行される。
```c
bool	is_expandable_data(t_expander *e, t_ast_node *node, char *original_data)
{
	if (!*node->data && node->type == COMMAND_ARG_NODE)
	{
		node->data = NULL;
		return (false);
	}
	else if (!*node->data && *original_data && node->type != COMMAND_ARG_NODE)
	{
		expand_redirect_error(original_data, e);
		return (false);
	}
	return (true);
}
```

- `word_splitting()`が`t_ast_node*`を返す必要がないことが判明したので、`void`方に変更し、この変更に伴い、エラー処理関数などの型も修正した。

- その他、関数名を若干変更した。

## Effect
- 環境変数周りのエラー処理をまた一つ潰せた。
- エラー処理をまとめたのと、関数名・型を変更したことで、多分可読性が向上した。

## Test
```bash
$ cd test
$ ./grademe.sh expansion
```